### PR TITLE
Documenting need to disable snapshots on vcloud cpi

### DIFF
--- a/deploy-with-bosh.html.md.erb
+++ b/deploy-with-bosh.html.md.erb
@@ -358,9 +358,14 @@ properties:
     address: 192.168.1.232
     port: 25555
     encryption: false
+    # Check if the CPI for your IaaS supports snapshots, otherwise disable it.
+    # As an example vCloud cpi 0.5.2 does not support snaphots
     enable_snapshots: true
     max_tasks: 100
     db: *bosh_db
+    # If needed, limit the number of threads used to concurrently instanciate new vms (32 by default)
+    # max_threads: 1
+
 
   hm:
     http:


### PR DESCRIPTION
Documenting need to disable snapshots on vcloud cpi + how to reduce vm creation rate

vcloud cpi does not yet supports snapshots. https://github.com/vchs/bosh_vcloud_cpi/blob/master/spec/unit/vcloud_spec.rb#L8
Snapshots are disabled by default. Enabling them explicitly as suggested previously breaks jobs restarts on bosh multi vms

```
E, [2014-04-08T12:58:29.978654 #7862] [task:227] ERROR -- : undefined method `snapshot_disk' for #<Bosh::Clouds::VCloud:0x0000000290cbb0>
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/api/snapshot_manager.rb:80:in `block in take_snapshot'
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/api/snapshot_manager.rb:79:in `each'
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/api/snapshot_manager.rb:79:in `take_snapshot'
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/instance_updater.rb:177:in `take_snapshot'
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/instance_updater.rb:65:in `block in update'
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/instance_updater.rb:40:in `step'
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/instance_updater.rb:65:in `update'
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/job_updater.rb:108:in `block (2 levels) in update_instance'
/var/vcap/packages/director/gem_home/gems/bosh_common-1.2175.0/lib/common/thread_formatter.rb:46:in `with_thread_name'
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/job_updater.rb:106:in `block in update_instance'
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/event_log.rb:83:in `call'
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/event_log.rb:83:in `advance_and_track'
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/job_updater.rb:103:in `update_instance'
/var/vcap/packages/director/gem_home/gems/bosh-director-1.2175.0/lib/bosh/director/job_updater.rb:97:in `block (2 levels) in update_instances'
/var/vcap/packages/director/gem_home/gems/bosh_common-1.2175.0/lib/common/thread_pool.rb:79:in `call'
/var/vcap/packages/director/gem_home/gems/bosh_common-1.2175.0/lib/common/thread_pool.rb:79:in `block (2 levels) in create_thread'
/var/vcap/packages/director/gem_home/gems/bosh_common-1.2175.0/lib/common/thread_pool.rb:63:in `loop'
/var/vcap/packages/director/gem_home/gems/bosh_common-1.2175.0/lib/common/thread_pool.rb:63:in `block in create_thread'
```
