### PR TITLE
Change instance type from m1.small to t2.small

### DIFF
--- a/deploy-microbosh-to-aws.html.md.erb
+++ b/deploy-microbosh-to-aws.html.md.erb
@@ -37,7 +37,7 @@ network:
 resources:
   persistent_disk: 20000
   cloud_properties:
-    instance_type: m1.small
+    instance_type: t2.small
     availability_zone: AVAILABILITY-ZONE # Replace with your Availability Zone
 
 cloud:


### PR DESCRIPTION
Suggest changing default instance type in the MicroBosh AWS manifest from m1.small, which does not support HVM to t2.small, which does, and are less expensive. (HVM stemcells are smaller to dl/ul.)