### PR TITLE
Putting properties in the spec file is mandatory

### DIFF
--- a/create-release.html.md.erb
+++ b/create-release.html.md.erb
@@ -716,12 +716,6 @@ properties:
      default: 80
 ~~~
 
-Note that the definition of properties and their defaults in the job's spec file is optional:
-Bosh will still expand properties in templates and update relevant jobs upon modifications of
-properties in the job manifest (bosh evaluates all the templates for all jobs and notices the differences in the
-result files. if there are changes bosh will update those jobs/vms.)
-
-
 ---
 ## <a id="dev-release"></a> Step 6: Create a Dev Release  ##
 


### PR DESCRIPTION
Properties that are not in the spec file are not available in the template expansion, right?