### PR TITLE
Added 'patch' to list of Centos dependencies

### DIFF
--- a/install-bosh-init.html.md.erb
+++ b/install-bosh-init.html.md.erb
@@ -41,7 +41,7 @@ Here are the latest binaries:
 	**CentOS**
 
 	<pre class="terminal">
-	$ sudo yum install gcc ruby ruby-devel mysql-devel postgresql-devel postgresql-libs sqlite-devel libxslt-devel libxml2-devel yajl-ruby
+	$ sudo yum install gcc ruby ruby-devel mysql-devel postgresql-devel postgresql-libs sqlite-devel libxslt-devel libxml2-devel yajl-ruby patch
 	</pre>
 
 	**Mac OS X**


### PR DESCRIPTION
I have several cases, bosh-init for AWS fails, when I use fresh new Amazon Centos 7 VM.
The failure appears on bosh_aws_cpi compilation, because system could not build native libxml extentions for nokogiri gem.