### PR TITLE
Generate private key and cert request in two steps

### DIFF
--- a/director-certs.html.md.erb
+++ b/director-certs.html.md.erb
@@ -36,10 +36,13 @@ extensions = san
 subjectAltName = IP:${ip}
 EOL
 
+  echo "Generating private key..."
+  openssl genrsa -out ${name}.key 2048
+
   echo "Generating certificate signing request for ${ip}..."
   # golang requires to have SAN for the IP
-  openssl req -new -nodes -newkey rsa:2048 \
-    -out ${name}.csr -keyout ${name}.key \
+  openssl req -new -nodes -key ${name}.key \
+    -out ${name}.csr
     -subj "/C=US/O=BOSH/CN=${ip}"
 
   echo "Generating certificate ${ip}..."


### PR DESCRIPTION
On Ubunutu with OpenSSL 1.0.1f using `openssl req` with option `-newkey rsa:2048`
the generated private key has PKCS#8 format -----BEGIN PRIVATE KEY-----
which is not accepted by UAA.
With `openssl genrsa` the generated private key has PKCS#1 format
-----BEGIN RSA PRIVATE KEY----- which is accepted by UAA.