### PR TITLE
Missing backslash in generate cert req command

### DIFF
--- a/director-certs.html.md.erb
+++ b/director-certs.html.md.erb
@@ -42,7 +42,7 @@ EOL
   echo "Generating certificate signing request for ${ip}..."
   # golang requires to have SAN for the IP
   openssl req -new -nodes -key ${name}.key \
-    -out ${name}.csr
+    -out ${name}.csr \
     -subj "/C=US/O=BOSH/CN=${ip}"
 
   echo "Generating certificate ${ip}..."


### PR DESCRIPTION
In my last pull request (commit 0148ba9) for generating private key and
cert request in two steps I forgot a backslash in the
multiline `openssl` command for generating the cert request.