### PR TITLE
Adapt example for hm.ca_cert in director-certs.html

### DIFF
--- a/director-certs.html.md.erb
+++ b/director-certs.html.md.erb
@@ -71,7 +71,7 @@ ls -la .
 - `director.ssl.cert`
     - Associated certificate for the Director (e.g. `certs/director.crt`)
 - `hm.ca_cert`
-    - CA certificate used by the HM to verify the Director's certificate (e.g. `certs/ca.key`)
+    - CA certificate used by the HM to verify the Director's certificate (e.g. `certs/rootCA.key`)
 
 If you are using the UAA for user management, additionally put certificates in these properties:
 


### PR DESCRIPTION
The value given as example didn't match the name of the file generated by the script.
Thought it would be better to have them consistent.