### PR TITLE
xoebus/gaol typo fix

### DIFF
--- a/warden-cpi.html.md.erb
+++ b/warden-cpi.html.md.erb
@@ -94,4 +94,4 @@ properties:
 ---
 ## <a id='notes'></a> Notes
 
-* Garden server does not have a UI; however, you can use [goal CLI](https://github.com/xoebus/gaol) to interact with it directly.
+* Garden server does not have a UI; however, you can use [gaol CLI](https://github.com/xoebus/gaol) to interact with it directly.


### PR DESCRIPTION
Garden CLI is actually called "gaol", not goal.