### PR TITLE
Fix hm.ca_cert to hm.director_account.ca_cert

### DIFF
--- a/director-certs.html.md.erb
+++ b/director-certs.html.md.erb
@@ -70,7 +70,7 @@ ls -la .
     - Private key for the Director (e.g. `certs/director.key`)
 - `director.ssl.cert`
     - Associated certificate for the Director (e.g. `certs/director.crt`)
-- `hm.ca_cert`
+- `hm.director_account.ca_cert`
     - CA certificate used by the HM to verify the Director's certificate (e.g. `certs/rootCA.key`)
 
 If you are using the UAA for user management, additionally put certificates in these properties:


### PR DESCRIPTION
The property mentioned in the documentation does not
match the property in the health_monitor spec file.
This patch fixes the documentation.