### PR TITLE
Fix CA certificate example

### DIFF
--- a/director-certs.html.md.erb
+++ b/director-certs.html.md.erb
@@ -74,7 +74,7 @@ Update the Director deployment manifest:
 - `director.ssl.cert`
     - Associated certificate for the Director (e.g. `certs/director.crt`)
 - `hm.director_account.ca_cert`
-    - CA certificate used by the HM to verify the Director's certificate (e.g. `certs/rootCA.key`)
+    - CA certificate used by the HM to verify the Director's certificate (e.g. `certs/rootCA.pem`)
 
 If you are using the UAA for user management, additionally put certificates in these properties:
 


### PR DESCRIPTION
The example points to the CA private key instead of its certificate. This can cause confusion and in the worst case some serious security issues.