### PR TITLE
deployment-manifest: cloud_properties for compilation

### DIFF
--- a/deployment-manifest.html.md.erb
+++ b/deployment-manifest.html.md.erb
@@ -91,7 +91,7 @@ See [networks](networks.html) for more details.
 * **stemcell** [Hash, required]: The stemcell used to create resource pool VMs.
     * **name** [String, required]: The stemcell name
     * **version** [String, required]: The stemcell version
-* **cloud_properties** [Hash, optional]: Describes any IaaS-specific properties needed to create compilation VMs. Examples: `instance_type`, `availability_zone`. Default is `{}` (empty Hash).
+* **cloud_properties** [Hash, optional]: Describes any IaaS-specific properties needed to create VMs; for most IaaSes, some data here is actually required. See [CPI Specific `cloud_properties`](#resource-pools-cloud-properties) below. Examples: `instance_type`, `availability_zone`. Default is `{}` (empty Hash).
 * **env** [Hash, optional]: Describes the VM environment and provides a specific VM environment to the CPI `create_stemcell` call. `env` data is available to BOSH Agents as VM settings. Default is `{}` (empty Hash).
 
 Example:
@@ -170,7 +170,7 @@ disk_pools:
 * **workers** [Integer, required]: The maximum number of compilation VMs.
 * **network** [String, required]: References a valid network name defined in the Networks block. BOSH assigns network properties to compilation VMs according to the type and properties of the specified network.
 * **reuse\_compilation\_vms** [Boolean, optional]: If `false`, BOSH creates a new compilation VM for each new package compilation and destroys the VM when compilation is complete. If `true`, compilation VMs are re-used when compiling packages. Defaults to `false`.
-* **cloud_properties** [Hash, optional]: Describes any IaaS-specific properties needed to create compilation VMs. Examples: `instance_type`, `availability_zone`. Default is `{}` (empty Hash).
+* **cloud_properties** [Hash, optional]: Describes any IaaS-specific properties needed to create compilation VMs; for most IaaSes, some data here is actually required. For the Compilation Block, the required `cloud_properties` are the same as for Resource Pools; see the [CPI Specific `cloud_properties`](#resource-pools-cloud-properties) for Resource Pools. Examples: `instance_type`, `availability_zone`. Default is `{}` (empty Hash).
 
 Example:
 


### PR DESCRIPTION
* Add link to CPI Specific `cloud_properties` in section for Resource Pools, and clarify that while it's technically optional, most IaaSes require data.
* Do the same for Compilation, since there's currently no clear documentation how to fill out its `cloud_properties` section.