### PR TITLE
Document aws.max_retries to fix throttling

### DIFF
--- a/aws-cpi.html.md.erb
+++ b/aws-cpi.html.md.erb
@@ -126,6 +126,7 @@ Schema:
 * **default\_security\_groups** [Array, required]: Name of the [Security Group](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html) that will be applied to all created VMs. Consistently use either security group names or IDs. Example: `[bosh]`
 * **default\_iam\_instance\_profile** [String, optional]: Name of the [IAM instance profile](aws-iam-instance-profiles.html) that will be applied to all created VMs. Example: `director`.
 * **region** [String, required]: AWS region name. Example: `us-east-1`
+* **max_retries** [Integer, optional]: The maximum number of times AWS service errors (500) and throttling errors (`AWS::EC2::Errors::RequestLimitExceeded`) should be retried. There is an exponential backoff in between retries, so the more retries the longer it can take to fail. Defaults to 2.
 
 See [all configuration options](https://bosh.io/jobs/cpi?source=github.com/cloudfoundry-incubator/bosh-aws-cpi-release).
 
@@ -223,6 +224,13 @@ Non-Windows instances with a virtualization type of 'hvm' are currently not supp
 ```
 
 You cannot use HVM stemcells with certain instance types. Review which instance type is specified in a referenced resource pool.
+
+
+```
+AWS::EC2::Errors::RequestLimitExceeded Request limit exceeded.
+```
+
+AWS API is throttling the number of request in your account. You can reduce the number of threads running in BOSH, or increase the value of `aws.max_retries` to let the AWS client library perform retries in a exponential backoff. Note that the more retries, the longer will take to fail.
 
 ---
 Next: [Using IAM instance profiles](aws-iam-instance-profiles.html)


### PR DESCRIPTION
Document that for the AWS CPI, the option aws.max_retries can be used to retry
in case of throttling.

This feature is added in the  https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/pull/23, to cover https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/issues/19. The PR in `bosh-aws-cpi-release` should be merged and released before merging this PR.