### PR TITLE
bosh-init requires package gcc-c++ on CentOS

### DIFF
--- a/install-bosh-init.html.md.erb
+++ b/install-bosh-init.html.md.erb
@@ -41,7 +41,7 @@ Here are the latest binaries:
 	**CentOS**
 
 	<pre class="terminal">
-	$ sudo yum install gcc ruby ruby-devel mysql-devel postgresql-devel postgresql-libs sqlite-devel libxslt-devel libxml2-devel yajl-ruby patch
+	$ sudo yum install gcc gcc-c++ ruby ruby-devel mysql-devel postgresql-devel postgresql-libs sqlite-devel libxslt-devel libxml2-devel yajl-ruby patch
 	</pre>
 
 	**Mac OS X**


### PR DESCRIPTION
Without this package, I get this error on a `bosh-init deploy`

```
Started installing CPI
  Compiling package 'ruby_aws_cpi/a5b66d011ce1b31642ff148ea2c9097af65ff78c'... Finished (00:00:00)
  Compiling package 'bosh_aws_cpi/bbd6a996bf1878cef323de6d8af7003ba35044f6'... Failed (00:00:55)
Failed installing CPI (00:00:55)

Command 'deploy' failed:
  Installing CPI:
    Compiling job package dependencies for installation:
      Compiling job package dependencies:
        Compiling package:
          Running command: 'bash -x packaging', stdout: 'Installing rake 10.3.2
Installing CFPropertyList 2.3.1
Installing addressable 2.3.8
Installing json 1.8.3
Installing mini_portile 0.6.2
Installing nokogiri 1.6.6.2
Installing aws-sdk-v1 1.60.2
Installing aws-sdk 1.60.2
Installing little-plugger 1.1.4
Installing multi_json 1.11.2
Installing logging 1.8.2
Installing semi_semantic 1.1.0
Installing bosh_common 1.3071.0
Installing membrane 1.1.0
Installing bosh_cpi 1.3071.0
Installing builder 3.2.2
Installing excon 0.45.4
Installing formatador 0.2.5
Installing mime-types 2.6.2
Installing net-ssh 2.9.2
Installing net-scp 1.2.1
Installing fog-core 1.32.1
Installing fog-xml 0.1.2
Installing fog-atmos 0.1.0
Installing fog-json 1.0.2
Installing ipaddress 0.8.0
Installing fog-aws 0.1.1
Installing inflecto 0.0.2
Installing fog-brightbox 0.9.0
Installing fog-ecloud 0.3.0
Installing fog-google 0.0.7
Installing fog-local 0.2.1
Installing fog-powerdns 0.1.1
Installing fog-profitbricks 0.0.5
Installing fog-radosgw 0.0.4
Installing fog-riakcs 0.1.0
Installing fog-sakuracloud 1.1.1
Installing fog-serverlove 0.1.2
Installing fog-softlayer 0.4.7
Installing fog-storm_on_demand 0.1.1
Installing fog-terremark 0.1.0
Installing fission 0.5.0
Installing fog-vmfusion 0.1.0
Installing fog-voxel 0.1.0
Installing fog 1.31.0
Installing sequel 3.43.0
Installing rack 1.6.4
Installing rack-protection 1.5.3
Installing tilt 2.0.1
Installing sinatra 1.4.6
Installing daemons 1.2.3

Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

    /home/ec2-user/.bosh_init/installations/fe5971a1-7670-4175-4bde-9cafa7130346/packages/ruby_aws_cpi/bin/ruby extconf.rb
checking for rb_trap_immediate in ruby.h,rubysig.h... no
checking for rb_thread_blocking_region()... yes
checking for ruby/thread.h... yes
checking for rb_thread_call_without_gvl() in ruby/thread.h... yes
checking for inotify_init() in sys/inotify.h... yes
checking for writev() in sys/uio.h... yes
checking for rb_thread_fd_select()... yes
checking for rb_fdset_t in ruby/intern.h... yes
checking for pipe2() in unistd.h... yes
checking for accept4() in sys/socket.h... yes
checking for SOCK_CLOEXEC in sys/socket.h... yes
checking for rb_wait_for_single_fd()... yes
checking for rb_enable_interrupt()... no
checking for rb_time_new()... yes
checking for sys/event.h... no
checking for epoll_create() in sys/epoll.h... yes
CFLAGS=-fPIC  -Wall -Wextra -Wno-deprecated-declarations -Wno-ignored-qualifiers -Wno-unused-result
CPPFLAGS= -I/usr/local/opt/openssl/include -I/home/ec2-user/.bosh_init/installations/fe5971a1-7670-4175-4bde-9cafa7130346/packages/ruby_aws_cpi/include $(DEFS) $(cppflags) -Wall -Wextra -Wno-deprecated-declarations -Wno-ignored-qualifiers -Wno-unused-result
checking for clock_gettime()... yes
checking for CLOCK_MONOTONIC_RAW in time.h... yes
checking for CLOCK_MONOTONIC in time.h... yes
creating Makefile

make "DESTDIR="
compiling kb.cpp
make: g++: Command not found
make: *** [kb.o] Error 127
```

But if I `sudo yum install gcc-c++` then the `bosh-init deploy` succeeds.