### PR TITLE
Update IAM policies to use subset of ec2 actions

### DIFF
--- a/aws-iam-instance-profiles.html.md.erb
+++ b/aws-iam-instance-profiles.html.md.erb
@@ -18,7 +18,26 @@ You may have to create one or more IAM instance profiles to limit access to AWS 
     {
       "Version": "2012-10-17",
       "Statement": [{
-        "Action": "ec2:*",
+        "Action": [
+          "ec2:AssociateAddress",
+          "ec2:AttachVolume",
+          "ec2:CreateVolume",
+          "ec2:DeleteSnapshot",
+          "ec2:DeleteVolume",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeImages",
+          "ec2:DescribeInstances",
+          "ec2:DescribeRegions",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSnapshots",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVolumes",
+          "ec2:DetachVolume",
+          "ec2:CreateSnapshot",
+          "ec2:CreateTags",
+          "ec2:RunInstances",
+          "ec2:TerminateInstances"
+        ],
         "Effect": "Allow",
         "Resource": "*"
       },{
@@ -87,7 +106,26 @@ This configuration is similar to the previous one except that it's used when the
     {
       "Version": "2012-10-17",
       "Statement": [{
-        "Action": "ec2:*",
+        "Action": [
+          "ec2:AssociateAddress",
+          "ec2:AttachVolume",
+          "ec2:CreateVolume",
+          "ec2:DeleteSnapshot",
+          "ec2:DeleteVolume",
+          "ec2:DescribeAddresses",
+          "ec2:DescribeImages",
+          "ec2:DescribeInstances",
+          "ec2:DescribeRegions",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSnapshots",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVolumes",
+          "ec2:DetachVolume",
+          "ec2:CreateSnapshot",
+          "ec2:CreateTags",
+          "ec2:RunInstances",
+          "ec2:TerminateInstances"
+        ],
         "Effect": "Allow",
         "Resource": "*"
       },{

--- a/aws-iam-users.html.md.erb
+++ b/aws-iam-users.html.md.erb
@@ -40,20 +40,37 @@ title: Creating IAM Users
 
     <%= image_tag("images/deploy-microbosh-to-aws/add-iam-inline-policy.png") %>
 
-    For example your aws-cpi's inline policy allows full EC2 and ELB access:
+    For example your aws-cpi's inline policy allows EC2 and full ELB access:
 
     ```yaml
     {
       "Version": "2012-10-17",
       "Statement": [
         {
-          "Sid": "Stmt1448388791000",
+          "Action": [
+            "ec2:AssociateAddress",
+            "ec2:AttachVolume",
+            "ec2:CreateVolume",
+            "ec2:DeleteSnapshot",
+            "ec2:DeleteVolume",
+            "ec2:DescribeAddresses",
+            "ec2:DescribeImages",
+            "ec2:DescribeInstances",
+            "ec2:DescribeRegions",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSnapshots",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeVolumes",
+            "ec2:DetachVolume",
+            "ec2:CreateSnapshot",
+            "ec2:CreateTags",
+            "ec2:RunInstances",
+            "ec2:TerminateInstances"
+          ],
           "Effect": "Allow",
-          "Action": [ "ec2:*" ],
-          "Resource": [ "*" ]
+          "Resource": "*"
         },
         {
-          "Sid": "Stmt1448389431000",
           "Effect": "Allow",
           "Action": [ "elasticloadbalancing:*" ],
           "Resource": [ "*" ]


### PR DESCRIPTION
I've been using the following subset of actions. Confirmed via CloudTrail logs that they're actively used.

I don't use ELB so can't update that statement.