### PR TITLE
Attempt to make the examples match their description

### DIFF
--- a/vcloud-cpi.html.md.erb
+++ b/vcloud-cpi.html.md.erb
@@ -44,7 +44,7 @@ resource_pools:
     name: bosh-vcloud-esxi-ubuntu-trusty-go_agent
     version: latest
   cloud_properties:
-    cpu: 2
+    cpu: 1
     ram: 1_024
     disk: 10_240
 ```

--- a/vsphere-cpi.html.md.erb
+++ b/vsphere-cpi.html.md.erb
@@ -53,7 +53,7 @@ resource_pools:
     name: bosh-vsphere-esxi-ubuntu-trusty-go_agent
     version: latest
   cloud_properties:
-    cpu: 2
+    cpu: 1
     ram: 1_024
     disk: 10_240
 
@@ -73,7 +73,7 @@ resource_pools:
     name: bosh-vsphere-esxi-ubuntu-trusty-go_agent
     version: latest
   cloud_properties:
-    cpu: 2
+    cpu: 1
     ram: 1_024
     disk: 10_240
 


### PR DESCRIPTION
The description before the examples state "example of a VM with 1 CPU", but then the cloud properties have "cpu: 2". I assume that this should be "cpu: 1". Both the vSphere and vCloud examples have the same description and cloud properties for the example.