### PR TITLE
Reword cloud-config opt-in warning

### DIFF
--- a/cloud-config.html.md.erb
+++ b/cloud-config.html.md.erb
@@ -2,7 +2,7 @@
 title: Cloud Config
 ---
 
-<p class="note">Note: This feature is available with bosh-release v241+. Once you opt into using cloud config all deployments must be converted to use new format. There is no way to opt out of the cloud config once you opt in.</p>
+<p class="note">Warning: Once you opt into using cloud config all deployments must be converted to use new format. There is no way to opt out of the cloud config once you opt in. Check all deployment manifest generation you use in your director are "cloud-config friendly" before opt-in. This feature is available with bosh-release v241+. </p>
 
 Previously each deployment manifest specified IaaS and IaaS agnostic configuration in a single file. As more deployments are managed by the Director, it becomes inconvenient to keep shared IaaS configuration in sync in all deployment manifests. In addition multiple deployments typically want to use the same network subnet, hence IP ranges need to be separated and reserved.
 


### PR DESCRIPTION
Most of the release manifest generation don't yet support cloud-config  (such as cf-release). Opt-in would prevent deploying them unless their manifest generation gets patched.

See related slack discussion at https://cloudfoundry.slack.com/archives/bosh-users/p1458080218000039