### PR TITLE
remove a note about bosh-lite

### DIFF
--- a/post-deploy.html.md.erb
+++ b/post-deploy.html.md.erb
@@ -2,7 +2,7 @@
 title: Post-deploy Script
 ---
 
-<p class="note">Note: This feature is available with bosh-release v255.4+ and only for releases deployed with 3125+ stemcells. bosh-lite support is planned but currently is not available since latest available stemcell for bosh-lite is 2774.</p>
+<p class="note">Note: This feature is available with bosh-release v255.4+ and only for releases deployed with 3125+ stemcells.</p>
 
 <p class="note">Note: Releases that make use of post-deploy scripts and are deployed on older stemcells or with an older Director may potentially deploy; however, post-deploy script will not be called.</p>
 

--- a/post-start.html.md.erb
+++ b/post-start.html.md.erb
@@ -2,7 +2,7 @@
 title: Post-start Script
 ---
 
-<p class="note">Note: This feature is available with bosh-release v255.4+ and only for releases deployed with 3125+ stemcells. bosh-lite support is planned but currently is not available since latest available stemcell for bosh-lite is 2774.</p>
+<p class="note">Note: This feature is available with bosh-release v255.4+ and only for releases deployed with 3125+ stemcells.</p>
 
 <p class="note">Note: Releases that make use of post-start scripts and are deployed on older stemcells or with an older Director may potentially deploy; however, post-start script will not be called.</p>
 

--- a/pre-start.html.md.erb
+++ b/pre-start.html.md.erb
@@ -2,7 +2,7 @@
 title: Pre-start Script
 ---
 
-<p class="note">Note: This feature is available with bosh-release v206+ (1.3072.0) and only for releases deployed with 3125+ stemcells. bosh-lite support is planned but currently is not available since latest available stemcell for bosh-lite is 2774.</p>
+<p class="note">Note: This feature is available with bosh-release v206+ (1.3072.0) and only for releases deployed with 3125+ stemcells.</p>
 
 <p class="note">Note: Releases that make use of pre-start scripts and are deployed on older stemcells or with an older Director may potentially deploy; however, pre-start script will not be called.</p>
 


### PR DESCRIPTION
Remove a note about bosh-lite as the current latest available stemcell version for bosh-lite is 3147.