### PR TITLE
Remove restriction on a mix of security group names and IDs

### DIFF
--- a/aws-cpi.html.md.erb
+++ b/aws-cpi.html.md.erb
@@ -25,7 +25,7 @@ azs:
 Schema for `cloud_properties` section used by dynamic network or manual network subnet:
 
 * **subnet** [String, required]: Subnet ID in which the instance will be created. Example: `subnet-9be6c3f7`.
-* **security_groups** [Array, optional]: Array of security groups to apply to all VMs placed on this network. Defaults to security groups specified by `default_security_groups` in the global CPI settings unless security groups are specified on a resource pool for a VM. Use either security group names or IDs, but be consistent. Security groups can be specified either on a resource pool or on a network.
+* **security_groups** [Array, optional]: Array of [Security Groups](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html), by name or ID, to apply to all VMs placed on this network. Security groups can be specified as follows, ordered by greatest precedence: `vm_types`, followed by `networks`, followed by `default_security_groups`.
 
 Example of manual network:
 
@@ -38,6 +38,7 @@ networks:
     gateway: 10.10.0.1
     cloud_properties:
       subnet: subnet-9be6c3f7
+      security_groups: [bosh]
 ```
 
 Example of dynamic network:
@@ -65,7 +66,7 @@ Schema for `cloud_properties` section:
 
 * **instance_type** [String, required]: Type of the [instance](http://aws.amazon.com/ec2/instance-types/). Example: `m3.medium`.
 * **availability_zone** [String, required]: Availability zone to use for creating instances. Example: `us-east-1a`.
-* **security_groups** [Array, optional]: Array of security groups to apply for all VMs that are in this resource pool. Defaults to security groups specified by `default_security_groups` in the global CPI settings unless security groups are specified on one of the VM networks. Security groups can be specified either on a resource pool or on a network. Available in v46+.
+* **security_groups** [Array, optional]: See description under [networks](#networks). Available in v46+.
 * **key_name** [String, optional]: Key pair name. Defaults to key pair name specified by `default_key_name` in global CPI settings. Example: `bosh`.
 * **spot\_bid\_price** [Float, optional]: Bid price in dollars for [AWS spot instance](http://aws.amazon.com/ec2/purchasing-options/spot-instances/). Using this option will slow down VM creation. Example: `0.03`.
 * **spot\_ondemand\_fallback** [Boolean, optional]: Set to `true` to use an on demand instance if a spot instance is not available during VM creation. Defaults to `false`. Available in v36.
@@ -140,7 +141,7 @@ Schema:
 * **access\_key\_id** [String, optional]: Accesss Key ID. Example: `AKI...`.
 * **secret\_access\_key** [String, optional]: Secret Access Key. Example: `0kwh...`.
 * **default\_key\_name** [String, required]: Name of the [Key Pair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) that will be applied to all created VMs. Example: `bosh`
-* **default\_security\_groups** [Array, required]: Name of the [Security Group](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html) that will be applied to all created VMs. Consistently use either security group names or IDs. Example: `[bosh]`
+* **default\_security\_groups** [Array, required]: See description under [networks](#networks).
 * **default\_iam\_instance\_profile** [String, optional]: Name of the [IAM instance profile](aws-iam-instance-profiles.html) that will be applied to all created VMs. Example: `director`.
 * **region** [String, required]: AWS region name. Example: `us-east-1`
 * **max_retries** [Integer, optional]: The maximum number of times AWS service errors (500) and throttling errors (`AWS::EC2::Errors::RequestLimitExceeded`) should be retried. There is an exponential backoff in between retries, so the more retries the longer it can take to fail. Defaults to 2.


### PR DESCRIPTION
- Also more clearly describes precedence of security groups fields
- Removes content duplication

[#119844019](https://www.pivotaltracker.com/story/show/119844019)

Signed-off-by: Corey Innis <cinnis@pivotal.io>