### PR TITLE
Update docs to reflect required key-value for az.cloud_properties.datacenters.clusters

### DIFF
--- a/vsphere-cpi.html.md.erb
+++ b/vsphere-cpi.html.md.erb
@@ -194,11 +194,11 @@ azs:
 - name: z1
   cloud_properties:
     datacenters:
-    - clusters: [z1]
+    - clusters: [z1: {}]
 - name: z2
   cloud_properties:
     datacenters:
-    - clusters: [z2]
+    - clusters: [z2: {}]
 
 vm_types:
 - name: default


### PR DESCRIPTION
 - The docs are wrong in this case, causing an error when #values gets called on a string.

Signed-off-by: Alvaro Perez-Shirley <aperezshirley@pivotal.io>