### PR TITLE
`gem install` docs use non-deprecated flags

### DIFF
--- a/bosh-cli.html.md.erb
+++ b/bosh-cli.html.md.erb
@@ -5,7 +5,7 @@ title: BOSH Command Line Interface
 BOSH Command Line Interface (CLI) is used to interact with the Director. The CLI is written in Ruby and is distributed via `bosh_cli` gem.
 
 <pre class="terminal">
-$ gem install bosh_cli --no-ri --no-rdoc
+$ gem install bosh_cli --no-document
 </pre>
 
 <p class="note">Note: BOSH CLI requires Ruby 2+</p>

--- a/create-release.html.md.erb
+++ b/create-release.html.md.erb
@@ -518,7 +518,7 @@ pushd rubygems-1.8.24
   ${BOSH_INSTALL_TARGET}/bin/ruby setup.rb
 popd
 
-${BOSH_INSTALL_TARGET}/bin/gem install ruby_1.9.3/bundler-1.2.1.gem --no-ri --no-rdoc
+${BOSH_INSTALL_TARGET}/bin/gem install ruby_1.9.3/bundler-1.2.1.gem --no-document
 ~~~
 
 #### <a id="pkg-script-ardo"></a> Example ardo_app packaging script ####

--- a/packages.html.md.erb
+++ b/packages.html.md.erb
@@ -93,7 +93,7 @@ pushd rubygems-1.8.24
   ${BOSH&#95;INSTALL&#95;TARGET}/bin/ruby setup.rb
 popd
 
-${BOSH&#95;INSTALL&#95;TARGET}/bin/gem install ruby&#95;1.9.3/bundler-1.2.1.gem --no-ri --no-rdoc
+${BOSH&#95;INSTALL&#95;TARGET}/bin/gem install ruby&#95;1.9.3/bundler-1.2.1.gem --no-document
 </pre>
 
 Example script referencing pre-compiled code:


### PR DESCRIPTION
--no-ri and --no-rdoc are deprecated in favor of --no-document