### PR TITLE
Fix how cross deployments links are referenced

### DIFF
--- a/links.html.md.erb
+++ b/links.html.md.erb
@@ -230,7 +230,7 @@ instance_groups:
   - name: web
     release: my-app
     consumes:
-      primary_db: {from: data-dep.db}
+      primary_db: {from: db, deployment: data-dep}
       secondary_db: nil
 ```
 


### PR DESCRIPTION
This integration test suggests that the docs are out-of-date : https://github.com/cloudfoundry/bosh/blob/master/spec/integration/links_spec.rb#L1009