### PR TITLE
Add AWS-specific manifest & explicitly mention antonsoroko's manifest  is OpenStack one

### DIFF
--- a/create-release.html.md.erb
+++ b/create-release.html.md.erb
@@ -767,7 +767,7 @@ See what releases are available:
 
 If BOSH is already pointing to a release, edit the BOSH deployment manifest.
 Otherwise, create a manifest. See [BOSH Deployment Manifest](./deployment-manifest.html) for more information.
-Simple manifest for `ardo_app` can be found [here](https://gist.github.com/antonsoroko/3be4c70b38f846b1d79eca7192a5ab58).
+Simple manifest for `ardo_app` can be found [here](https://gist.github.com/antonsoroko/3be4c70b38f846b1d79eca7192a5ab58) (OpenStack) or [here](https://gist.github.com/uzzz/9ad9cad105032fecdbeb223798607a87) (AWS).
 
 Upload the new dev release.
 


### PR DESCRIPTION
New guy from our team was confused when he was trying to deploy release using OpenStack-specific manifest to AWS.