### PR TITLE
Add minimal BOSH version that supports v2 schema

### DIFF
--- a/manifest-v2.html.md.erb
+++ b/manifest-v2.html.md.erb
@@ -2,7 +2,7 @@
 title: Manifest v2 Schema
 ---
 
-<p class="note">Note: This feature is available with bosh-release v255.4+.</p>
+<p class="note">Note: This feature is available with bosh-release v255.4+ (BOSH version 1.3213.0+).</p>
 
 <p class="note">Note: Once you opt into using cloud config all deployments must be converted to use manifest v2 format that disallows IaaS specific configuration.</p>
 


### PR DESCRIPTION
As a BOSH user bosh-release version doesn't tell me anything:

```
ubuntu@cf-dev:~/ui$ bosh status
Config
             /home/ubuntu/.bosh_config

Director
RSA 1024 bit CA certificates are loaded due to old openssl compatibility
  Name       my-bosh
  URL        https://192.168.111.10:25555
  Version    1.3262.3.0 (00000000)
  User       admin
  UUID       4a83bab3-c9e1-4ec4-a78e-e7ea1e6d4f6f
  CPI        openstack_cpi
  dns        disabled
  compiled_package_cache disabled
  snapshots  disabled
```

so it would be good to have BOSH version as well