### PR TITLE
Document usage of AWS CPI `source_dest_check`

### DIFF
--- a/aws-cpi.html.md.erb
+++ b/aws-cpi.html.md.erb
@@ -76,6 +76,11 @@ Schema for `cloud_properties` section:
 * **tenancy** [String, optional]: VM [tenancy](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/dedicated-instance.html) configuration. Example: `dedicated`. Default is `default`.
 * **auto\_assign\_public\_ip** [Boolean, optional]: Assigns a public IP address to the created VM. This IP is ephemeral and may change; use an [Elastic IP](networks.html#vip) instead for a persistent address. Defaults to `false`. Available in v55+.
 * **raw\_instance\_storage** [Boolean, optional]: Exposes all available [instance storage via labeled disks](aws-instance-storage.html). Defaults to `false`.
+* **source\_dest\_check** [Boolean, optional]: Specifies whether the instance
+  must be the source or destination of any traffic it sends or receives. If set
+  to `false`, the instance does *not* need to be the source or destination.
+  Used for network address translation (NAT) boxes, frequently to communicate
+  between VPCs. Defaults to `true`. Available in v59+.
 * **ephemeral_disk** [Hash, optional]: EBS backed ephemeral disk of custom size. Default disk size is either the size of first instance storage disk, if the instance_type offers it, or 10GB. Before v53: Used EBS only if instance storage is not large enough or not available for selected instance type.
     * **size** [Integer, required]: Specifies the disk size in megabytes.
     * **type** [String, optional]: Type of the [disk](http://aws.amazon.com/ebs/details/): `standard`, `gp2`. Defaults to `gp2`.


### PR DESCRIPTION
- Allows user to specify whether the instance must be the source or destination
  of any traffic it sends or receives

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>

[#129712307](https://www.pivotaltracker.com/story/show/129712307)