### PR TITLE
Don't change ownership recursively in startup script

### DIFF
--- a/create-release.html.md.erb
+++ b/create-release.html.md.erb
@@ -131,7 +131,7 @@ case $1 in
 
   start)
     mkdir -p $RUN_DIR $LOG_DIR
-    chown -R vcap:vcap $RUN_DIR $LOG_DIR
+    chown vcap:vcap $RUN_DIR $LOG_DIR
 
     echo $$ > $PIDFILE
 


### PR DESCRIPTION
pre-start might already have written some logs, we shouldn't change the ownership.