### PR TITLE
Add vSphere distributed virtual switch naming hint

### DIFF
--- a/vsphere-cpi.html.md.erb
+++ b/vsphere-cpi.html.md.erb
@@ -36,6 +36,12 @@ Schema for `cloud_properties` section used by manual network subnet:
 
 * **name** [String, required]: Name of the vSphere network. Example: `VM Network`.
 
+**Note:** To assign a distributed virtual portgroup when
+there exists a standard virtual portgroup with the same name,
+prepend the distributed virtual switch's name followed by a slash to the
+distributed virtual portgroup, e.g. `dvs/distributed-portgroup-1`. This may
+be required when working with VxRack. Available in v28+.
+
 Example of manual network:
 
 ```yaml


### PR DESCRIPTION
- Newest CPI resolves ambiguity when a standard portgroup and a
  distributed portgroup have the same name by allowing operator to
  specify `dvs/portgroup-1`

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>

[#129725111](https://www.pivotaltracker.com/story/show/129725111)