### PR TITLE
Fix HTML typo

### DIFF
--- a/director-api-v1.html.md.erb
+++ b/director-api-v1.html.md.erb
@@ -2,7 +2,7 @@
 title: Director API v1
 ---
 
-<p class="note">Note: Before using the Director API directly, we strongly encourage to consider using the CLI for automation such as performing a scheduled deploy from a CI. We hope that you will open a <a href="https://github.com/cloudfoundry/bosh/issues">GitHub issue</a> to share your use cases so that we can suggest or possibly make additions to the CLI.</a>
+<p class="note">Note: Before using the Director API directly, we strongly encourage to consider using the CLI for automation such as performing a scheduled deploy from a CI. We hope that you will open a <a href="https://github.com/cloudfoundry/bosh/issues">GitHub issue</a> to share your use cases so that we can suggest or possibly make additions to the CLI.</p>
 
 This document lists common API endpoints provided by the Director.
 


### PR DESCRIPTION
The page formatting is currently bugged due to a closing a-tag instead of a p-tag after the note, see https://bosh.io/docs/director-api-v1.html