### PR TITLE
Typo/Formatting fixes

### DIFF
--- a/compiled-releases.html.md.erb
+++ b/compiled-releases.html.md.erb
@@ -43,7 +43,7 @@ To export a release:
       update_watch_time: 1000-90000
     ```
 
-    <p class="note">Note: This example assumes you are using [cloud config](cloud-config.html), hence no compilation, networks and other sections were defined. If you are not using cloud config you will have to define them.</p>
+    <p class="note">Note: This example assumes you are using <a href="./cloud-config.html">cloud config</a>, hence no compilation, networks and other sections were defined. If you are not using cloud config you will have to define them.</p>
 
 1. Reference desired release versions you want to export.
 

--- a/director-api-v1.html.md.erb
+++ b/director-api-v1.html.md.erb
@@ -2,7 +2,7 @@
 title: Director API v1
 ---
 
-<p class="note">Note: Before using the Director API directly, we strongly encourage to consider using the CLI for automation such as performing a scheduled deploy from a CI. We hope that you will open a <a href="https://github.com/cloudfoundry/bosh/issues">GitHub issue</a> to share your use cases so that we can suggest or possibly make additions to the CLI.</a>
+<p class="note">Note: Before using the Director API directly, we strongly encourage to consider using the CLI for automation such as performing a scheduled deploy from a CI. We hope that you will open a <a href="https://github.com/cloudfoundry/bosh/issues">GitHub issue</a> to share your use cases so that we can suggest or possibly make additions to the CLI.</a></p>
 
 This document lists common API endpoints provided by the Director.
 

--- a/uploading-releases.html.md.erb
+++ b/uploading-releases.html.md.erb
@@ -24,7 +24,7 @@ Assuming that the CLI is already targeted at the Director, the CLI provides a si
 - If you have a URL to a release tarball (for example a URL provided by bosh.io):
 
 	<pre class="terminal">
-	$ bosh upload release https:http://bosh.io/d/github.com/cloudfoundry/cf-release
+	$ bosh upload release https://bosh.io/d/github.com/cloudfoundry/cf-release
 	</pre>
 
 	Alternatively, if you have a release tarball on your local machine:


### PR DESCRIPTION
comiled-releases: bad link, can't use markdown inside of html block
director-api-v1: missing end of </p> block messes up formatting page
uploading-releases: https:http should be https: