### PR TITLE
Use consistent markdown for link names

### DIFF
--- a/links.html.md.erb
+++ b/links.html.md.erb
@@ -4,7 +4,7 @@ title: Links
 
 <p class="note">Note: This feature is available with bosh-release v255.5+.</p>
 
-Previously, if network communication was required between jobs, release authors had to add job properties to accept other job's network addresses (e.g. a "db_ips" property). Operators then had to explicitly assign static IPs or DNS names for each instance group and fill out network address properties. Such configuration typically relied on some helper tool like spiff or careful manual configuration. It also led to inconsistent network configuration as different jobs named their properties differently. All of that did not make it easy to automate and operate multiple environments.
+Previously, if network communication was required between jobs, release authors had to add job properties to accept other job's network addresses (e.g. a `db_ips` property). Operators then had to explicitly assign static IPs or DNS names for each instance group and fill out network address properties. Such configuration typically relied on some helper tool like spiff or careful manual configuration. It also led to inconsistent network configuration as different jobs named their properties differently. All of that did not make it easy to automate and operate multiple environments.
 
 Links provide a solution to the above problem by making the Director responsible for the IP management. Release authors get a consistent way of retrieving networking (and topology) configuration, and operators have a way to consistently connect components.
 
@@ -15,9 +15,9 @@ Instead of defining properties for every instance group, a job can declare links
 
 In the below yaml snippet the `name` field is used to differentiate between two links of the same `type` (`db`). Both the `name` and `type` that are provided can be arbitrarily defined by release authors. Other releases which consume these links must match the `type` specified.
 
-For example, here is how a "web" job which receives HTTP traffic and talks to at least one database server may be defined. To connect to a database, it consumes `primary_db` and `secondary_db` links of type `db`. It also exposes an "incoming" link of type `http` so that other services can connect to it.
+For example, here is how a `web` job which receives HTTP traffic and talks to at least one database server may be defined. To connect to a database, it consumes `primary_db` and `secondary_db` links of type `db`. It also exposes an "incoming" link of type `http` so that other services can connect to it.
 
-Note that when the `web` job is 'consuming' db links, the name of the link does not have to match the name of the provided db link (i.e. postgres has a link called `conn` while the web job consumes `primary_db` and/or `secondary_db`). The mapping between the provided link named `conn` and the consumed link named `primary_db` is done in the [deployment manifest file](#deployment).
+Note that when the `web` job is 'consuming' db links, the name of the link does not have to match the name of the provided db link (i.e. postgres has a link called `conn` while the `web` job consumes `primary_db` and/or `secondary_db`). The mapping between the provided link named `conn` and the consumed link named `primary_db` is done in the [deployment manifest file](#deployment).
 
 ```yaml
 name: web
@@ -38,7 +38,7 @@ provides:
 properties: {...}
 ```
 
-Note that the `secondary_db` link has been marked as optional, to indicate that the "web" job will work correctly, even if the operator does not provide a "secondary_db" link. Providing the `secondary_db` link may enable some additional functionality.
+Note that the `secondary_db` link has been marked as optional, to indicate that the `web` job will work correctly, even if the operator does not provide a `secondary_db` link. Providing the `secondary_db` link may enable some additional functionality.
 
 Here is an example Postgres job that provides a `conn` link of type `db`.
 
@@ -110,7 +110,7 @@ See [link properties](links-properties.html) for including additional link infor
 ---
 ## <a id="deployment"></a> Deployment Configuration
 
-Given the "web" and "postgres" job examples above, one can configure a deployment that connects a web app to the database. The following example demonstrates linking defined explicitly in the manifest by saying which jobs provide and consume a link `data_db`.
+Given the `web` and `postgres` job examples above, one can configure a deployment that connects a web app to the database. The following example demonstrates linking defined explicitly in the manifest by saying which jobs provide and consume a link `data_db`.
 
 ```yaml
 instance_groups:
@@ -138,7 +138,7 @@ Optional links are also implicitly connected; however, if no provider can be fou
 
 Implicit linking does not happen across deployments.
 
-In the following example, it's unnecessary to explicitly specify that web job consumes the "primary_db" link of type "db" from the postgres release job, since the postgres job is the only one that provides a link of type "db".
+In the following example, it's unnecessary to explicitly specify that `web` job consumes the `primary_db` link of type `db` from the postgres release job, since the postgres job is the only one that provides a link of type `db`.
 
 ```yaml
 instance_groups:
@@ -178,7 +178,7 @@ instance_groups:
 
 By default, links include network addresses on the producer's default link network. The default link network is a network marked with `default: [gateway]`. A release job can also consume a link over a different network.
 
-For example, this "web" job will receive "data_db"'s network addresses on its "vip" network, instead of receiving network addresses from the "private" network.
+For example, this `web` job will receive `data_db`'s network addresses on its `vip` network, instead of receiving network addresses from the `private` network.
 
 ```yaml
 instance_groups:


### PR DESCRIPTION
There was a formatting issue in the [links documentation](https://bosh.io/docs/links.html). This will hopefully fix it!

(As an aside, if "web" needs to be changed I can do that as well and update this pull request)