### PR TITLE
BOSH Documentation for vSphere NSX integration

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -102,6 +102,7 @@ See [Recent Additions and Updates](recent.html).
 * [vSphere](vsphere-cpi.html)
     * [Migrating from one datastore to another](vsphere-migrate-datastores.html)
     * [Storage DRS and vMotion Support](vsphere-vmotion-support.html)
+    * [NSX Support](vsphere-nsx.html)
 * [vCloud](vcloud-cpi.html)
 * SoftLayer (coming soon)
 * Google Compute Engine (coming soon)

--- a/vsphere-cpi.html.md.erb
+++ b/vsphere-cpi.html.md.erb
@@ -11,7 +11,7 @@ Schema for `cloud_properties` section:
 * **datacenters** [Array, optional]: Array of datacenters to use for VM placement. Must have only one and it must match datacenter configured in global CPI options.
     * **name** [String, required]: Datacenter name.
     * **clusters** [Array, required]: Array of clusters to use for VM placement.
-        * **\<cluster name\>** [String, required]: Cluster name.
+        * **&lt;cluster name&gt;** [String, required]: Cluster name.
             * **resource_pool** [String, optional]: Name of vSphere Resource Pool to use for VM placement.
             * **drs_rules** [Array, optional]: Array of DRS rules applied to [constrain VM placement](vm-anti-affinity.html#vsphere). Must have only one.
                 * **name** [String, required]: Name of a DRS rule that the Director will create.
@@ -72,7 +72,16 @@ Schema for `cloud_properties` section:
 
 * **datacenters** [Array, optional]: Used to override the VM placement specified under `azs.cloud_properties`. The format is the same as under [`AZs`](#azs).
 
-Example of a VM asked to be placed into a specific vSphere resource pool:
+* **nsx** [Dictionary, optional]: [VMWare NSX](http://www.vmware.com/products/nsx.html) additions section. Available in CPI v30+ and NSX v6.1+.
+  * **security_groups** [Array, optional]: A collection of [security group](https://pubs.vmware.com/NSX-6/index.jsp#com.vmware.nsx.admin.doc/GUID-16B3134E-DDF1-445A-8646-BB0E98C3C9B5.html) names that the instances should belong to. The CPI will create the security groups if they do not exist.
+  * **lbs** [Array, optional]: A collection of [NSX Edge Load Balancers](https://pubs.vmware.com/NSX-6/index.jsp?topic=%2Fcom.vmware.nsx.admin.doc%2FGUID-152982CF-108F-47A6-B86A-0F0F6A56D628.html) (LBs) to which instances should be attached. The LB and [Server Pool](https://pubs.vmware.com/NSX-6/index.jsp?topic=%2Fcom.vmware.nsx.admin.doc%2FGUID-D5A3BDBA-57A6-43F4-AE5E-3A387FE69EDC.html) must exist prior to the deployment.
+    * **edge_name** [String, required]: Name of the NSX Edge.
+    * **pool_name** [String, required]: Name of the Edge's Server Pool.
+    * **security_group** [String, required]: Name of the Pool's target Security Group. The CPI will add the VM to the specified security group (creating the security group if needed), then add the security group to the specified Server Pool.
+    * **port** [Integer, required]: The port that the VM's service is listening on (e.g. 80 for HTTP).
+    * **monitor_port** [Integer, optional]: The healthcheck port that the VM is listening on. Defaults to the value of `port`.
+
+Example of a VM asked to be placed into a specific vSphere resource pool with NSX integration:
 
 ```yaml
 resource_pools:
@@ -91,6 +100,14 @@ resource_pools:
     - name: my-dc
       clusters:
       - my-vsphere-cluster: {resource_pool: other-vsphere-res-pool}
+    nsx:
+      security_groups: [public, dmz]
+      lbs:
+      - edge_name: my-lb
+        pool_name: https-pool
+        security_group: https-sg
+        port: 443
+        monitor_port: 4443 # optional, defaults to `port` value
 ```
 
 ---
@@ -143,7 +160,7 @@ Schema:
 * **host** [String, required]: IP address of the vCenter. Example: `172.16.68.3`.
 * **user** [String, required]: Username for the API access. Example: `root`.
 * **password** [String, required]: Password for the API access. Example: `vmware`
-* **default_disk_type** [String, optional]: Sets the default
+* **default\_disk\_type** [String, optional]: Sets the default
   [disk type](https://www.vmware.com/support/developer/converter-sdk/conv51_apireference/vim.VirtualDiskManager.VirtualDiskType.html).
   Can be either `thin` or `preallocated`, defaults to `preallocated`. `preallocated`
   sets "all space allocated at [VM] creation time and the space is zeroed on demand as the space is used",
@@ -152,17 +169,25 @@ Schema:
 
 * **datacenters** [Array, optional]: Array of datacenters to use for VM placement. Must have only one.
     * **name** [String, required]: Datacenter name.
-
     * **vm_folder** [String, required]: Path to a folder (relative to the datacenter) for storing created VMs. Folder will be automatically created if not found.
     * **template_folder** [String, required]: Path to a folder (relative to the datacenter) for storing uploaded stemcells. Folder will be automatically created if not found.
     * **disk_path** [String, required]: Path to a *disk* folder for storing persistent disks. Folder will be automatically created in the datastore if not found.
-
     * **datastore_pattern** [String, required]: Pattern for selecting datastores for storing ephemeral disks and replicated stemcells.
     * **persistent\_datastore\_pattern** [String, required]: Pattern for selecting datastores for storing persistent disks.
-
     * **clusters** [Array, required]: Array of clusters to use for VM placement.
-        * **\<cluster name\>** [String, required]: Cluster name.
+        * **&lt;cluster name&gt;** [String, required]: Cluster name.
             * **resource_pool** [String, optional]: Specific vSphere resource pool to use within the cluster.
+
+* **nsx** [Dictionary, optional]: NSX configuration options.  This is required if the other NSX features are used below (e.g. 'security_groups' for `resource_pools`).
+    * **address** [String, required]: The NSX server's address. Can be a hostname (e.g. `nsx-server.example.com`) or an IP address.
+    * **user** [String, required]: The login username for the NSX server.
+    * **password** [String, required]: The login password for the NSX server.
+    * **ca_cert** [String, optional]: A CA certificate that can authenticate the NSX server certificate. **Required** if the NSX Manager has a self-signed SSL certificate. Must be in PEM format.
+
+<p class="note">
+Note: If the NSX Manager has a self-signed certificate, the certificate must be set in the `ca_cert` property; the following command can be used to extract the certificate from the NSX Manager:
+`true | openssl s_client -connect YOUR_NSX_MANAGER:443 2>/dev/null | openssl x509`.
+</p>
 
 Example of a CPI configuration that will place VMs into `BOSH_CL` cluster within `BOSH_DC`:
 
@@ -182,7 +207,7 @@ properties:
       clusters: [BOSH_CL]
 ```
 
-Or example that places VMs by default into `BOSH_RP` vSphere resource pool:
+Or example that places VMs by default into `BOSH_RP` vSphere resource pool with NSX integration:
 
 ```yaml
 properties:
@@ -200,6 +225,10 @@ properties:
       persistent_datastore_pattern: '\Aprod-ds\z'
       clusters:
       - BOSH_CL: {resource_pool: BOSH_RP}
+    nsx:
+      address: 172.16.68.4
+      user: administrator@vsphere.local
+      password: vmware
 ```
 
 ---

--- a/vsphere-cpi.html.md.erb
+++ b/vsphere-cpi.html.md.erb
@@ -74,6 +74,7 @@ Schema for `cloud_properties` section:
 
 * **nsx** [Dictionary, optional]: [VMWare NSX](http://www.vmware.com/products/nsx.html) additions section. Available in CPI v30+ and NSX v6.1+.
   * **security_groups** [Array, optional]: A collection of [security group](https://pubs.vmware.com/NSX-6/index.jsp#com.vmware.nsx.admin.doc/GUID-16B3134E-DDF1-445A-8646-BB0E98C3C9B5.html) names that the instances should belong to. The CPI will create the security groups if they do not exist.
+  BOSH will also automatically create security groups based on metadata such as deployment name and instance group name. The full list of groups can be seen under [create_vm's environment groups](cpi-api-v1.html#create-vm).
   * **lbs** [Array, optional]: A collection of [NSX Edge Load Balancers](https://pubs.vmware.com/NSX-6/index.jsp?topic=%2Fcom.vmware.nsx.admin.doc%2FGUID-152982CF-108F-47A6-B86A-0F0F6A56D628.html) (LBs) to which instances should be attached. The LB and [Server Pool](https://pubs.vmware.com/NSX-6/index.jsp?topic=%2Fcom.vmware.nsx.admin.doc%2FGUID-D5A3BDBA-57A6-43F4-AE5E-3A387FE69EDC.html) must exist prior to the deployment.
     * **edge_name** [String, required]: Name of the NSX Edge.
     * **pool_name** [String, required]: Name of the Edge's Server Pool.


### PR DESCRIPTION
- documents how to configure NSX Security Groups in Director's manifest and in resource pool
- documents how to configure NSX LBs
- fixed `default_disk_type` malformatting

[#127508577](https://www.pivotaltracker.com/story/show/127508577)

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>