### PR TITLE
Add instructions for vSphere HA interoperation

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -100,6 +100,7 @@ See [Recent Additions and Updates](recent.html).
     * [Validating self-signed OpenStack endpoints](openstack-self-signed-endpoints.html)
     * [Multi-homed VMs](openstack-multiple-networks.html)
 * [vSphere](vsphere-cpi.html)
+    * [vSphere HA](vsphere-ha.html)
     * [Migrating from one datastore to another](vsphere-migrate-datastores.html)
     * [Storage DRS and vMotion Support](vsphere-vmotion-support.html)
 * [vCloud](vcloud-cpi.html)

--- a/init-vsphere.html.md.erb
+++ b/init-vsphere.html.md.erb
@@ -107,6 +107,8 @@ jobs:
     hm:
       director_account: {user: hm, password: hm-password}
       resurrector_enabled: true
+      intervals:
+        agent_timeout: 180
 
     vcenter: &vcenter # <--- Replace values below
       address: VCENTER-IP

--- a/init.html.md.erb
+++ b/init.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: Intializing an environment
+title: Initializing an environment
 ---
 
 A single BOSH environment consists of the Director and deployments that it orchestrates. To create an empty environment, we first need to deploy the Director. The Director VM will include all necessary BOSH components that will be used to manage different IaaS resources.

--- a/vsphere-cpi.html.md.erb
+++ b/vsphere-cpi.html.md.erb
@@ -313,4 +313,4 @@ Could not acquire HTTP NFC lease, message is: 'A specified parameter was not cor
 The [vCenter docs](https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.DefaultPowerOpInfo.html) show that the value should be `preset` rather than `default` inside the OVF file. Switching `powerOpInfo.*` properties resolved the problem.
 
 ---
-Next: [Migrating from one datastore to another](vsphere-migrate-datastores.html)
+Next: [vSphere HA](vsphere-ha.html)

--- a/vsphere-esxi-host-failure.html.md.erb
+++ b/vsphere-esxi-host-failure.html.md.erb
@@ -2,6 +2,8 @@
 title: Recovery from an ESXi Host Failure
 ---
 
+<p class="note">Note: Do not follow this procedure if vSphere HA is enabled and bosh-vsphere-cpi is v30+; vSphere HA will automatically recreate VMs that were on the failed host.</p>
+
 This topic describes how to recreate VMs in the event of an ESXi host failure.
 The BOSH Resurrector is unable to recreate a VM on a failed ESXi host without
 manual intervention.
@@ -48,6 +50,6 @@ The following steps will allow the Resurrector to recreate these VMs on a health
 ---
 [Back to Table of Contents](index.html#cpi-config)
 
-Previous: [Storage DRS and vMotion Support](vsphere-vmotion-support.html)
+Previous: [vSphere HA](vsphere-ha.html)
 
 Next: [Recovery from a vSphere Network Partitioning Fault](vsphere-network-partition.html)

--- a/vsphere-ha.html.md.erb
+++ b/vsphere-ha.html.md.erb
@@ -1,0 +1,43 @@
+---
+title: vSphere HA
+---
+
+vSphere High Availability (HA) is a VMware product that detects ESXi host failure, for example host power off or network partition, and automatically restarts virtual machines on other hosts in the cluster.
+It can interoperate effectively with the [BOSH Resurrector](resurrector.html), which recreates VMs if the Director loses contact with a VM's BOSH Agent.
+
+<p class="note">Note: This feature is available with bosh-vsphere-cpi v30+.</p>
+
+### vCenter Configuration
+
+Configure vSphere HA as follows:
+
+* Check ***Cluster* &rarr; Manage &rarr; Settings &rarr; vSphere HA &rarr;
+Edit... &rarr; Turn on vSphere HA**
+
+* Check **Host Monitoring**
+
+* Ensure the Response for **Failure conditions and VM response &rarr; Host Isolation** is set to **Shut down and restart VMs**
+
+### BOSH Director Configuration
+
+Increase the timeout values of the [BOSH Health Monitor](monitoring.html#vm) on the BOSH Director to allow for smooth interoperation between BOSH and vCenter.
+We recommend increasing the `agent_timeout` from the default 60s to 180s in the BOSH Director's manifest to allow vCenter time to detect the failed host:
+
+```yaml
+jobs:
+- name: bosh
+  properties:
+    ...
+    hm:
+      resurrector_enabled: true
+      intervals:
+        agent_timeout: 180
+```
+
+<p class="note"> Warning: If vSphere HA is not enabled on the cluster and a host failure occurs, the BOSH Resurrector will be unable to recreate the VMs without manual intervention.
+Follow the manual procedure as appropriate: [Host Failure](vsphere-esxi-host-failure.html) or [Network Partition](vsphere-network-partition.html).</p>
+
+---
+[Back to Table of Contents](index.html#cpi-config)
+
+Next: [Migrating from one datastore to another](vsphere-migrate-datastores.html)

--- a/vsphere-migrate-datastores.html.md.erb
+++ b/vsphere-migrate-datastores.html.md.erb
@@ -39,4 +39,4 @@ This topic describes how to migrate VMs and persistent disks from one datastore 
 
 Next: [Storage DRS and vMotion Support](vsphere-vmotion-support.html)
 
-Previous: [vSphere](vsphere-cpi.html)
+Previous: [vSphere HA](vsphere-ha.html)

--- a/vsphere-network-partition.html.md.erb
+++ b/vsphere-network-partition.html.md.erb
@@ -2,6 +2,9 @@
 title: Recovery from a vSphere Network Partitioning Fault
 ---
 
+<p class="note">Note: Do not follow this procedure if vSphere HA is enabled and bosh-vsphere-cpi is v30+;
+vSphere HA will automatically recreate VMs that were on the partitioned host.</p>
+
 This topic describes how to recreate VMs in the event of a network partition
 that disrupts the following:
 

--- a/vsphere-vmotion-support.html.md.erb
+++ b/vsphere-vmotion-support.html.md.erb
@@ -6,13 +6,15 @@ title: Storage DRS and vMotion Support
 
 <p class="note">Warning: If a VM was accidentally deleted after a disk was migrated via DRS or vMotion, BOSH may be unable to locate the disk.</p>
 
-Typically Storage DRS and vMotion moves attached persistent disks with the VM. When doing so it renames attached disks and places them into moved VM folder (typically called `vm-<uuid>`). Prior to bosh-vsphere-cpi v18, Storage DRS and vMotion were not supported since the CPI was unable to locate renamed disks. Later versions of the CPI are able to locate disks migrated by vSphere as long as the disks are attached to the VMs.
+Typically Storage DRS and vMotion moves attached persistent disks with the VM.
+When doing so it renames attached disks and places them into moved VM folder (typically called `vm-<uuid>`).
+Prior to bosh-vsphere-cpi v18, Storage DRS and vMotion were not supported since the CPI was unable to locate renamed disks.
+Later versions of the CPI are able to locate disks migrated by vSphere as long as the disks are attached to the VMs.
 
-As VMs are recreated, the CPI will move persistent disks out of VM folders so that they are not deleted with the VMs. This procedure will happen automatically when VMs are deleted (in `delete_vm` CPI call) and when disks are detached (in `detach_disk` CPI call).
+As VMs are recreated, the CPI will move persistent disks out of VM folders so that they are not deleted with the VMs.
+This procedure will happen automatically when VMs are deleted (in `delete_vm` CPI call) and when disks are detached (in `detach_disk` CPI call).
 
 ---
 [Back to Table of Contents](index.html#cpi-config)
-
-Next: [Recovery from an ESXi host failure](vsphere-esxi-host-failure.html)
 
 Previous: [Migrating from one datastore to another](vsphere-migrate-datastores.html)


### PR DESCRIPTION
- Adds a dedicated "vSphere HA" page
- Includes setup instructions for vSphere UI and BOSH Director
- Bumps `agent_timeout` in Resurrector to give vCenter time to detect the failed host
- also fixed typo "Intializing"

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>

[#127290967](https://www.pivotaltracker.com/story/show/127290967)