### PR TITLE
Add openssl to list of prerequisites needed on CentOS

### DIFF
--- a/install-bosh-init.html.md.erb
+++ b/install-bosh-init.html.md.erb
@@ -41,7 +41,7 @@ Here are the latest binaries:
 	**CentOS**
 
 	<pre class="terminal">
-	$ sudo yum install gcc gcc-c++ ruby ruby-devel mysql-devel postgresql-devel postgresql-libs sqlite-devel libxslt-devel libxml2-devel yajl-ruby patch
+	$ sudo yum install gcc gcc-c++ ruby ruby-devel mysql-devel postgresql-devel postgresql-libs sqlite-devel libxslt-devel libxml2-devel yajl-ruby patch openssl
 	</pre>
 
 	**Mac OS X**


### PR DESCRIPTION
We found this was needed when running bosh-init deploy in a fresh CentOS Docker container.