### PR TITLE
Azure manifest renames `cpi` job to `azure_cpi`

### DIFF
--- a/init-azure.html.md.erb
+++ b/init-azure.html.md.erb
@@ -70,7 +70,7 @@ jobs:
   - {name: director, release: bosh}
   - {name: health_monitor, release: bosh}
   - {name: registry, release: bosh}
-  - {name: cpi, release: bosh-azure-cpi}
+  - {name: azure_cpi, release: bosh-azure-cpi}
 
   resource_pool: vms
   persistent_disk_pool: disks
@@ -116,7 +116,7 @@ jobs:
       address: 127.0.0.1
       name: my-bosh
       db: *db
-      cpi_job: cpi
+      cpi_job: azure_cpi
       max_threads: 10
       user_management:
         provider: local
@@ -146,7 +146,7 @@ jobs:
     ntp: &ntp [0.pool.ntp.org, 1.pool.ntp.org]
 
 cloud_provider:
-  template: {name: cpi, release: bosh-azure-cpi}
+  template: {name: azure_cpi, release: bosh-azure-cpi}
 
   ssh_tunnel:
     host: PUBLIC-IP # <--- Replace


### PR DESCRIPTION
fixes:
```
Invalid CPI release 'bosh-azure-cpi': CPI release must contain specified job 'cpi'
```

Commit that changed `cpi` to `azure_cpi`: https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/commit/8a74356b94ee3954f58c481f2014b7496d89657b