### PR TITLE
Azure environment acquires necessary privileges

### DIFF
--- a/azure-resources.html.md.erb
+++ b/azure-resources.html.md.erb
@@ -38,6 +38,14 @@ Once you've determined your subscription ID, switch to using that account:
 $ azure account set 3c39a033-c306-4615-a4cb-260418d63879
 </pre>
 
+Register the required providers:
+
+<pre class="terminal">
+$ azure provider register Microsoft.Network
+$ azure provider register Microsoft.Storage
+$ azure provider register Microsoft.Compute
+</pre>
+
 ---
 ## <a id="client"></a> Client
 
@@ -70,7 +78,7 @@ Application ID (`33e56099-0bde-8z93-a005-89c0f6df7465` in the above output) is t
 Finally create service principal to enable authenticated access:
 
 <pre class="terminal">
-$ azure ad sp create 33e56099-0bde-8z93-a005-89c0f6df7465
+$ azure ad sp create service_principal --applicationId 33e56099-0bde-8z93-a005-89c0f6df7465
 $ azure role assignment create --roleName "Contributor" --spn "http://BOSHAzureCPI" --subscription 3c39a033-c306-4615-a4cb-260418d63879
 </pre>
 
@@ -151,7 +159,8 @@ $ azure network nsg rule create --resource-group bosh-res-group --nsg-name nsg-c
 ---
 ## <a id="storage-account"></a> Storage Account
 
-Create a default storage account to hold root disks, persistent disks, stemcells, etc.:
+Create a default storage account to hold root disks, persistent disks, stemcells, etc.
+If unsure of desired SKU Name, choose `LRS`, desired Kind, choose `Storage`:
 
 <pre class="terminal">
 $ azure storage account create boshstore --resource-group bosh-res-group --location "Central US"


### PR DESCRIPTION
- `azure ad sp create service_principal` has correct arguments
- provide guidance when creating storage account (**LRS**, **Storage**)

fixes:
```
error:   The subscription is not registered to use namespace 'Microsoft.Storage'. See https://aka.ms/rps-not-found for how to register subscriptions.
error:   Error information has been recorded to /Users/cunnie/.azure/azure.err
error:   storage account create command failed
```

fixes:
```
error:   The subscription is not registered to use namespace 'Microsoft.Network'. See https://aka.ms/rps-not-found for how to register subscriptions.
error:   Error information has been recorded to /Users/cunnie/.azure/azure.err
error:   network vnet create command failed
```

fixes:
```
Deploying:
  Creating instance 'bosh/0':
    Creating VM:
      Creating vm with stemcell cid 'bosh-stemcell-9185c8f7-d18c-4ffb-a136-45ac65c2b777':
        CPI 'create_vm' method responded with error: CmdError{"type":"Bosh::Clouds::VMCreationFailed","message":"#\u003cBosh::AzureCloud::AzureConflictError: http_put - http code: 409\nx-ms-client-request-id: \nx-ms-request-id: cb6d7b64-dd4f-4b09-a22f-ccc0bc838764\nx-ms-correlation-request-id: cb6d7b64-dd4f-4b09-a22f-ccc0bc838764\nx-ms-routing-request-id: WESTUS:20161015T174904Z:cb6d7b64-dd4f-4b09-a22f-ccc0bc838764\nError message: {\"error\":{\"code\":\"MissingSubscriptionRegistration\",\"message\":\"The subscription is not registered to use namespace 'Microsoft.Compute'. See https://aka.ms/rps-not-found for how to register subscriptions.\"}}\u003e\n/Users/cunnie/.bosh_init/installations/b207aa68-a9b1-470a-6c61-1c171e0a8485/packages/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb:1180:in `check_completion'\n/Users/cunnie/.bosh_init/installations/b207aa68-a9b1-470a-6c61-1c171e0a8485/packages/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb:1268:in `http_put'\n/Users/cunnie/.bosh_init/installations/b207aa68-a9b1-470a-6c61-1c171e0a8485/packages/bosh_azure_cpi/lib/cloud/azure/azure_client2.rb:227:in `create_virtual_machine'\n/Users/cunnie/.bosh_init/installations/b207aa68-a9b1-470a-6c61-1c171e0a8485/packages/bosh_azure_cpi/lib/cloud/azure/vm_manager.rb:44:in `create'\n/Users/cunnie/.bosh_init/installations/b207aa68-a9b1-470a-6c61-1c171e0a8485/packages/bosh_azure_cpi/lib/cloud/azure/cloud.rb:112:in `block in create_vm'\n/Users/cunnie/.bosh_init/installations/b207aa68-a9b1-470a-6c61-1c171e0a8485/packages/bosh_azure_cpi/vendor/bundle/ruby/2.2.0/gems/bosh_common-1.3262.4.0/lib/common/thread_formatter.rb:49:in `with_thread_name'\n/Users/cunnie/.bosh_init/installations/b207aa68-a9b1-470a-6c61-1c171e0a8485/packages/bosh_azure_cpi/lib/cloud/azure/cloud.rb:105:in `create_vm'\n/Users/cunnie/.bosh_init/installations/b207aa68-a9b1-470a-6c61-1c171e0a8485/packages/bosh_azure_cpi/vendor/bundle/ruby/2.2.0/gems/bosh_cpi-1.3262.4.0/lib/bosh/cpi/cli.rb:70:in `public_send'\n/Users/cunnie/.bosh_init/installations/b207aa68-a9b1-470a-6c61-1c171e0a8485/packages/bosh_azure_cpi/vendor/bundle/ruby/2.2.0/gems/bosh_cpi-1.3262.4.0/lib/bosh/cpi/cli.rb:70:in `run'\n/Users/cunnie/.bosh_init/installations/b207aa68-a9b1-470a-6c61-1c171e0a8485/packages/bosh_azure_cpi/bin/azure_cpi:35:in `\u003cmain\u003e'","ok_to_retry":false}
```