### PR TITLE
underscores escaped

### DIFF
--- a/vsphere-cpi.html.md.erb
+++ b/vsphere-cpi.html.md.erb
@@ -143,7 +143,7 @@ Schema:
 * **host** [String, required]: IP address of the vCenter. Example: `172.16.68.3`.
 * **user** [String, required]: Username for the API access. Example: `root`.
 * **password** [String, required]: Password for the API access. Example: `vmware`
-* **default_disk_type** [String, optional]: Sets the default
+* **default\_disk\_type** [String, optional]: Sets the default
   [disk type](https://www.vmware.com/support/developer/converter-sdk/conv51_apireference/vim.VirtualDiskManager.VirtualDiskType.html).
   Can be either `thin` or `preallocated`, defaults to `preallocated`. `preallocated`
   sets "all space allocated at [VM] creation time and the space is zeroed on demand as the space is used",


### PR DESCRIPTION
The underscores on default_disk_type were missing and the markdown italicized the property.