### PR TITLE
Adding disaster recovery in index

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -117,6 +117,7 @@ See [Recent Additions and Updates](recent.html).
 * [Process monitoring with Monit](vm-monit.html)
 * [Manual repair with Cloud Check](cck.html)
 * [Automatic repair with Resurrector](resurrector.html)
+* [Disaster Recovery](disaster-recovery.html)
 * [Persistent disk snapshotting](snapshots.html)
 
 ### <a id="vm-config"></a> VM configuration (looking inside a deployment)


### PR DESCRIPTION
To make this content available since 2014 more discoverable from the bosh.io/docs entry point