### PR TITLE
Include `addressable` into networks and jobs documentation

### DIFF
--- a/jobs.html.md.erb
+++ b/jobs.html.md.erb
@@ -103,3 +103,4 @@ Each template can also access special `spec` object for instance specific config
 - `<%%= spec.az %>`: Inserts instance AZ.
 - `<%%= spec.address %>`: Inserts default instance network address (IPv4, IPv6 or DNS record). Available in bosh-release v255.4+.
 - `<%% spec.networks %>`: Allows to evaluate instance's network information.
+- `<%% spec.ip %>`: Inserts IP address of the instance. In case of multiple IP addresses available, the IP of the [addressable or default network](networks.html#multi-homed) is used. Available in bosh-release v258+.

--- a/networks.html.md.erb
+++ b/networks.html.md.erb
@@ -223,7 +223,7 @@ A deployment job can be configured to have multiple IP addresses (multiple NICs)
 
 Schema for `default` property:
 
-* **default** [Array, optional]: Configures this network to provide its settings for specific category as a default. Possible values are: `dns` and `gateway`. Both values can be specified together.
+* **default** [Array, optional]: Configures this network to provide its settings for specific category as a default. Possible values are: `dns`, `gateway` and since bosh-release v258 `addressable`. All values can be specified together. `addressable` can be used to specify which IP address other jobs see.
 
 Example:
 


### PR DESCRIPTION
spec.ip is available since v258. So far it is only
mentioned in the [release notes](https://github.com/cloudfoundry/bosh/releases/tag/v258).

This PR adds `spec.ip` in the [job properties](https://bosh.io/docs/jobs.html#properties) section. Furthermore it adds `addressable` to the possible default values in the [Multi-homed VMs](https://bosh.io/docs/networks.html#multi-homed) section.

Feel free to change the wording or add the order of the spec.ip value. It should come from [here](https://github.com/cloudfoundry/bosh/blob/master/bosh-director/lib/bosh/director/deployment_plan/instance_spec.rb#L139), stating that `addressable` precedes `gateway`.