### PR TITLE
Add docs for nova-networking compatibility

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -95,6 +95,7 @@ See [Recent Additions and Updates](recent.html).
     * [Creating resources](azure-resources.html)
 * [OpenStack](openstack-cpi.html)
     * [Using Keystone v2 API](openstack-keystonev2.html)
+    * [Using nova-networking](openstack-nova-networking.html)
     * [Extended Registry configuration](openstack-registry.html)
     * [Human-readable VM names](openstack-human-readable-vm-names.html)
     * [Validating self-signed OpenStack endpoints](openstack-self-signed-endpoints.html)

--- a/init-openstack.html.md.erb
+++ b/init-openstack.html.md.erb
@@ -182,7 +182,7 @@ cloud_provider:
     * [Image](http://www.openstack.org/software/openstack-shared-services/):
         BOSH stores stemcells using the Image service.
     * **(Optional)** [OpenStack Networking](http://www.openstack.org/software/openstack-networking/):
-        Provides network scaling and automated management functions that are useful when deploying complex distributed systems.
+        Provides network scaling and automated management functions that are useful when deploying complex distributed systems. **Note:** OpenStack networking is used as default as of v28 of the OpenStack CPI. To disable the use of the OpenStack Networking project, see [using nova-networking](openstack-nova-networking.html).
 
 1. The following OpenStack networks:
     * An external network with a subnet.

--- a/openstack-keystonev2.html.md.erb
+++ b/openstack-keystonev2.html.md.erb
@@ -28,6 +28,6 @@ title: Using Keystone API v2
 ---
 [Back to Table of Contents](index.html#cpi-config)
 
-Next: [Extended Registry configuration](openstack-registry.html)
+Next: [Using nova-networking](openstack-nova-networking.html)
 
 Previous: [OpenStack](openstack-cpi.html)

--- a/openstack-nova-networking.html.md.erb
+++ b/openstack-nova-networking.html.md.erb
@@ -1,0 +1,28 @@
+---
+title: Using nova-networking
+---
+
+<p class="note">Note: This feature is available with bosh-openstack-cpi v28+.</p>
+
+The OpenStack CPI v28+ uses neutron networking by default. This document describes how to enable nova-networking instead if your OpenStack installation doesn't provide neutron. **Note:** nova-networking is deprecated as of the OpenStack Newton release and will be removed in the future.
+
+1. Configure OpenStack CPI
+
+    Modify [the default template](init-openstack.html#create-manifest). In `properties.openstack`:
+    - add property `use_nova_networking: true`
+
+    ```yaml
+    properties:
+      openstack: &openstack
+        (...)
+        use_nova_networking: true
+    ```
+
+1. Deploy the Director
+
+---
+[Back to Table of Contents](index.html#cpi-config)
+
+Next: [Extended Registry configuration](openstack-registry.html)
+
+Previous: [Using Keystone API v2](openstack-keystonev2.html)

--- a/openstack-registry.html.md.erb
+++ b/openstack-registry.html.md.erb
@@ -28,4 +28,4 @@ title: Extended Registry configuration
 
 Next: [Using human-readable VM names](openstack-human-readable-vm-names.html)
 
-Previous: [Using Keystone API v2](openstack-keystonev2.html)
+Previous: [Using nova-networking](openstack-nova-networking.html)


### PR DESCRIPTION
As of release v28, neutron is the default.