### PR TITLE
No package yajl-ruby available in CentOS.

### DIFF
--- a/install-bosh-init.html.md.erb
+++ b/install-bosh-init.html.md.erb
@@ -41,7 +41,8 @@ Here are the latest binaries:
 	**CentOS**
 
 	<pre class="terminal">
-	$ sudo yum install gcc gcc-c++ ruby ruby-devel mysql-devel postgresql-devel postgresql-libs sqlite-devel libxslt-devel libxml2-devel yajl-ruby patch openssl
+	$ sudo yum install gcc gcc-c++ ruby ruby-devel mysql-devel postgresql-devel postgresql-libs sqlite-devel libxslt-devel libxml2-devel patch openssl
+	$ gem install yajl-ruby
 	</pre>
 
 	**Mac OS X**


### PR DESCRIPTION
The package yajl-ruby isn't available in CentOS. it can be installed in the end with:
```
gem install yajl-ruby
```