### PR TITLE
Azure: Cannot use Standard_A0 as instance_type of BOSH Director VM

### DIFF
--- a/azure-cpi.html.md.erb
+++ b/azure-cpi.html.md.erb
@@ -329,5 +329,10 @@ compilation:
 
   It is recommended to use the latest version. For example, Stemcell v3232.5 or later, and CPI v12 or later. You may hit the issue [#135](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/issues/135) if you still use an older stemcell than v3232.5.
 
+* Out of memory
+
+  If you hit `Out of memory` or `Virtual memory exhausted`, please check whether you use Standard_A0 as instance_type. You should change instance_type to a VM size with more memory.
+  Please reference the issue [#230](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/issues/230).
+
 ---
 [Back to Table of Contents](index.html#cpi-config)

--- a/init-azure.html.md.erb
+++ b/init-azure.html.md.erb
@@ -40,7 +40,7 @@ resource_pools:
     url: {{ .Stemcell.UserVisibleDownloadURL }}
     sha1: {{ .Stemcell.SHA1 }}
   cloud_properties:
-    instance_type: Standard_D1
+    instance_type: Standard_D1 # Instance size must have 1.75GiB RAM or greater (do not use Standard_A0).
 
 disk_pools:
 - name: disks


### PR DESCRIPTION
Thanks @cunnie to report this issue [#230](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/issues/230)

This PR is to add how to handle 'Out of memory' when using Standard_A0 for BOSH director VM on Azure.