### PR TITLE
Add info on AWS lb_target_groups cloud property

### DIFF
--- a/aws-cpi.html.md.erb
+++ b/aws-cpi.html.md.erb
@@ -71,6 +71,7 @@ Schema for `cloud_properties` section:
 * **spot\_bid\_price** [Float, optional]: Bid price in dollars for [AWS spot instance](http://aws.amazon.com/ec2/purchasing-options/spot-instances/). Using this option will slow down VM creation. Example: `0.03`.
 * **spot\_ondemand\_fallback** [Boolean, optional]: Set to `true` to use an on demand instance if a spot instance is not available during VM creation. Defaults to `false`. Available in v36.
 * **elbs** [Array, optional]: Array of ELB names that should be attached to created VMs. Example: `[prod-elb]`. Default is `[]`.
+* **lb_target_groups** [Array, optional]: Array of Load Balancer Target Groups to which created VMs should be attached. Example: `[prod-group1, prod-group2]`. Default is `[]`. Available in v63 or newer.
 * **iam\_instance\_profile** [String, optional]: Name of an [IAM instance profile](aws-iam-instance-profiles.html). Example: `director`.
 * **placement_group** [String, optional]: Name of a [placement group](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html). Example: `my-group`.
 * **tenancy** [String, optional]: VM [tenancy](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/dedicated-instance.html) configuration. Example: `dedicated`. Default is `default`.


### PR DESCRIPTION
* AWS CPI now supports attaching instances to Load Balancer Target
Groups. This is necessary for VMs to be attached to Application Load
Balancers.

[#135963933](https://www.pivotaltracker.com/story/show/135963933)

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>