### PR TITLE
vSphere opaque networks available in v40+

### DIFF
--- a/vsphere-cpi.html.md.erb
+++ b/vsphere-cpi.html.md.erb
@@ -42,6 +42,8 @@ prepend the distributed virtual switch's name followed by a slash to the
 distributed virtual portgroup, e.g. `dvs/distributed-portgroup-1`. This may
 be required when working with VxRack. Available in v28+.
 
+**Note:** The name may also be an NSX opaque network. Available in v40+.
+
 Example of manual network:
 
 ```yaml


### PR DESCRIPTION
We've added a note about this feature. when the release is cut we should merge this in with the correct vSphere release version number.

Love,
Zak and Brian