### PR TITLE
Azure: Add description for pip_idle_timeout_in_minutes

### DIFF
--- a/azure-cpi.html.md.erb
+++ b/azure-cpi.html.md.erb
@@ -181,6 +181,7 @@ Schema:
 * **parallel\_upload\_thread\_num** [Integer, optional]: The number of threads to upload stemcells in parallel. The default value is 16.
 * **debug_mode** [Boolean, optional]: Enable debug mode to log all raw HTTP requests/responses. The default value is false.
 * **use\_managed\_disks** [Boolean, optional]: Enable managed disks. The default value is `false`. Available in V21+.
+* **pip\_idle\_timeout\_in\_minutes** [Integer, optional]: Set idle timeouts in minutes for dynamic public IPs. It must be in the range [4, 30]. The default value is 4. It is only used when **assign\_dynamic\_public\_ip** is set to `true` in **resouce_pool**. Available in V24+.
 
 See [all configuration options](https://bosh.io/jobs/cpi?source=github.com/cloudfoundry-incubator/bosh-azure-cpi-release).
 


### PR DESCRIPTION
This is a new feature in Azure CPI [v24](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/releases/tag/v24).

- Support to set idle timeout in minutes for dynamic public IPs by configuring pip_idle_timeout_in_minutes in global Azure properties.
  - The default idle timeout of Azure public IPs is 4 minutes. The available value is [4, 30]. It must be integer.
  - If the interval that your applications send keep-alive is longer than the idle timeout, the TCP connections from/to the public IPs will be closed by Azure. So you need to increase the idle timeout of public IPs or decrease the interval in your applications.
  - If you set a too big value as the idle timeout, all ports associated with public IPs may be exhausted if your applications do not close TCP connections properly.