### PR TITLE
Added extra ssh flags for SOCKS proxy setup

### DIFF
--- a/cli-tunnel.html.md.erb
+++ b/cli-tunnel.html.md.erb
@@ -13,7 +13,11 @@ Common use cases for tunneling through a jumpbox VM include:
 
 <pre class="terminal">
 # set a tunnel
-$ ssh -D 5000 jumpbox@jumpbox-ip -i jumpbox.key
+# -D : local SOCKS port
+# -f : forks the process in the background
+# -C : compresses data before sending
+# -N : tells SSH that no command will be sent once the tunnel is up
+$ ssh -D 5000 -fNC jumpbox@jumpbox-ip -i jumpbox.key
 
 # let CLI know via environment variable
 $ export BOSH_ALL_PROXY=socks5://localhost:5000


### PR DESCRIPTION
From recently walking through this process I found the additional flags to be helpful and inline with other vendor recommendations when setting up a SOCKS proxy.