### PR TITLE
Update vsphere-esxi-host-failure.html.md.erb

### DIFF
--- a/vsphere-esxi-host-failure.html.md.erb
+++ b/vsphere-esxi-host-failure.html.md.erb
@@ -2,7 +2,7 @@
 title: Recovery from an ESXi Host Failure
 ---
 
-<p class="note">Note: Do not follow this procedure if vSphere HA is enabled and bosh-vsphere-cpi is v30+; vSphere HA will automatically recreate VMs that were on the failed host.</p>
+<p class="note">Note: Do not follow this procedure if vSphere HA is enabled and bosh-vsphere-cpi is v30+; vSphere HA will automatically move all VMs from the failed host to other good hosts.</p>
 
 This topic describes how to recreate VMs in the event of an ESXi host failure.
 The BOSH Resurrector is unable to recreate a VM on a failed ESXi host without


### PR DESCRIPTION
Corrected language pertaining to what vSphere HA actually does in the event of a host failure.

vSphere HA does not recreate VMs because it does not actually destroy them.

It unregisters the VMs from the failed host and then registers VMs on good hosts - no VM files are deleted. The process is just started on another host using the same exact config files and virtual disk files which reside on shared storage.