### PR TITLE
Update create-release.html.md.erb

### DIFF
--- a/create-release.html.md.erb
+++ b/create-release.html.md.erb
@@ -31,7 +31,7 @@ Then you can do a final release.
 To create the release directory, navigate into the workspace where you want the
 release to be, and run:
 
-  `bosh init release <release_name>`
+  `bosh init-release <release_name>`
 
 You can add the `--git` option to initialize a git repository.
 Use dashes in the release name.


### PR DESCRIPTION
I am not sure when the docs will migrate to bosh 2.0 but when trying to create a release with the [command in the docs](url) using `bosh init release` returns an error `Unknown command 'init'.`

```
$ bosh init release web-app
Unknown command `init'. Please specify one command of: add-blob, alias-env, attach-disk, blobs, cancel-task, clean-up, cloud-check, cloud-config, cpi-config, create-env, create-release, delete-deployment, delete-disk, delete-env, delete-release, delete-snapshot, delete-snapshots, delete-stemcell, delete-vm, deploy, deployment, deployments, disks, environment, environments, errands, event, events, export-release, finalize-release, generate-job, generate-package, help, ignore, init-release, inspect-release, instances, interpolate, locks, log-in, log-out, logs, manifest, orphan-disk, recreate, releases, remove-blob, repack-stemcell, reset-release, restart, run-errand, runtime-config, scp, snapshots, ssh, start, stemcells, stop, sync-blobs, take-snapshot, task, tasks, unignore, update-cloud-config, update-cpi-config, update-resurrection, update-runtime-config, upload-blobs, upload-release, upload-stemcell, variables or vms

Exit code 1
```
Using the [`bosh init-release`](https://bosh.io/docs/cli-v2#init-release) command, I was able to successfully create a release. 

```
$ bosh init-release --git --dir web-app
Succeeded
$ cd web-app/
```

List the files in the generated directory. 

```
$ tree
.
├── config
│   ├── blobs.yml
│   └── final.yml
├── jobs
├── packages
└── src

4 directories, 2 files
```

Version
```
bosh --version
version 2.0.23-a5bb0df-2017-05-31T21:21:01Z

Succeeded
```