### PR TITLE
Document BOSH_LOG_LEVEL environment variable

### DIFF
--- a/cli-v2.html.md.erb
+++ b/cli-v2.html.md.erb
@@ -922,6 +922,10 @@ See [CPI config](cpi-config.html).
 ---
 ### <a id="misc"></a> Misc
 
+- <a id="debug"></a> `BOSH_LOG_LEVEL=debug bosh ...`
+
+    The BOSH_LOG_LEVEL environment variable controls the verbosity of log printed on stdout. Valid values are DEBUG, INFO, WARN, ERROR, NONE.
+
 - <a id="clean-up"></a> `bosh -e my-env clean-up [--all]`
 
     Cleans up releases, stemcells, orphaned disks, and other unused resources.


### PR DESCRIPTION
So that users can discover how to turn on verbose logging. 

See https://github.com/cloudfoundry/bosh-cli/issues/113 and https://github.com/cloudfoundry/bosh-utils/blob/f8bb60f0bb8b25aeeafe837e5e851ec3d7d850e0/logger/logger.go#L24-L30