### PR TITLE
openstack: default_security_groups is an array

### DIFF
--- a/init-openstack.html.md.erb
+++ b/init-openstack.html.md.erb
@@ -162,7 +162,7 @@ You must create and configure two Security Groups to restrict incoming network t
         -v auth_url=test \
         -v az=test \
         -v default_key_name=test \
-        -v default_security_groups=test \
+        -v default_security_groups=[test] \
         -v net_id=test \
         -v openstack_password=test \
         -v openstack_username=test \


### PR DESCRIPTION
Mentioned in the [cf-bosh list](https://lists.cloudfoundry.org/archives/list/cf-bosh@lists.cloudfoundry.org/thread/MYFBT4BX4MWXWJK7E5P2EXW22H3OI4UQ/), and [pretty sure](https://github.com/cloudfoundry/bosh-deployment/blob/aa535b782756028fe527c6b99fe9247db24e2d00/openstack/cpi.yml#L75) it's supposed to be an array.