### PR TITLE
Update the sample YML for cloud config network

### DIFF
--- a/softlayer-cpi.html.md.erb
+++ b/softlayer-cpi.html.md.erb
@@ -26,14 +26,14 @@ networks:
   type: dynamic
   subnets:
   - az: z1
-  - dns: [10.1.2.3, 10.0.80.11, 10.0.80.12]
-  cloud_properties:
-    PrimaryNetworkComponent:
-       NetworkVlan:
-          Id: 524956
-    PrimaryBackendNetworkComponent:
-       NetworkVlan:
-          Id: 524954
+    dns: [10.1.2.3, 10.0.80.11, 10.0.80.12]
+    cloud_properties:
+      PrimaryNetworkComponent:
+         NetworkVlan:
+            Id: 524956
+      PrimaryBackendNetworkComponent:
+         NetworkVlan:
+            Id: 524954
 ```
 
 Example of dynamic network (only private network is available):
@@ -44,12 +44,12 @@ networks:
   type: dynamic
   subnets:
   - az: z1
-  - dns: [10.1.2.3, 10.0.80.11, 10.0.80.12]
-  cloud_properties:
-    PrivateNetworkOnlyFlag: true
-    PrimaryBackendNetworkComponent:
-       NetworkVlan:
-          Id: 524954
+    dns: [10.1.2.3, 10.0.80.11, 10.0.80.12]
+    cloud_properties:
+      PrivateNetworkOnlyFlag: true
+      PrimaryBackendNetworkComponent:
+         NetworkVlan:
+             Id: 524954
 ```
 
 Example of manual network:


### PR DESCRIPTION
The YML was incorrect with it's indentation and structure in the networking examples for cloud_config