### PR TITLE
Fix blobstore private.yml example

### DIFF
--- a/s3-release-blobstore.html.md.erb
+++ b/s3-release-blobstore.html.md.erb
@@ -38,7 +38,7 @@ An IAM user is used to download and upload blobs to a created S3 bucket.
 ```yaml
 ---
 blobstore:
-  options:
+  s3:
     access_key_id: <access_key_id>
     secret_access_key: <secret_access_key>
 ```


### PR DESCRIPTION
Seems like the format for `private.yml` changed at some point.