### PR TITLE
Update director-configure-blobstore for GCS

### DIFF
--- a/director-configure-blobstore.html.md.erb
+++ b/director-configure-blobstore.html.md.erb
@@ -72,3 +72,54 @@ The Director and the Agents can use an S3 compatible blobstore. Here is how to c
         bucket_name: test-bosh-bucket
         host: objects.dreamhost.com
     ```
+
+---
+## <a id="gcs"></a> Google Cloud Storage (GCS)
+
+The Director and the Agents can use GCS as a blobstore. Here is how to configure it:
+
+1. [Create a GCS bucket](https://cloud.google.com/storage/docs/creating-buckets).
+
+1. Create a [Service Account](https://developers.google.com/identity/protocols/OAuth2ServiceAccount),
+[fetch its Service Account File](https://cloud.google.com/iam/docs/creating-managing-service-account-keys),
+and [grant it](https://cloud.google.com/iam/docs/granting-roles-to-service-accounts)
+the `storage.objectAdmin` IAM role
+
+1. Ensure that access to the bucket is protected, as the Director may store sensitive information.
+
+1. Modify deployment manifest for the Director and specify GCS credentials and bucket name:
+
+    ```yaml
+    properties:
+      blobstore:
+        provider: gcs
+        json_key: |
+          SERVICE-ACCOUNT-FILE
+        bucket_name: test-bosh-bucket
+    ```
+
+1. To use [Customer Supplied Encryption Keys](https://cloud.google.com/storage/docs/encryption#customer-supplied)
+to encrypt blobstore contents instead of server-side encryption keys, specify `encryption_key`:
+
+    ```yaml
+    properties:
+      blobstore:
+        provider: gcs
+        json_key: |
+          SERVICE-ACCOUNT-FILE
+        bucket_name: test-bosh-bucket
+        encryption_key: BASE64-ENCODED-32-BYTES
+    ```
+
+1. To use an explicit [Storage Class](https://cloud.google.com/storage/docs/storage-classes)
+to store blobstore contents instead of the bucket default, specify `storage_class`:
+
+    ```yaml
+    properties:
+      blobstore:
+        provider: gcs
+        json_key: |
+          SERVICE-ACCOUNT-FILE
+        bucket_name: test-bosh-bucket
+        storage_class: REGIONAL
+    ```


### PR DESCRIPTION
bosh-cli has merged support for using GCS as a director blobstore. BOSH director and the google CPI are merging support.
This change documents GCS usage.
https://github.com/cloudfoundry/bosh/pull/1732
https://github.com/cloudfoundry/bosh-cli/pull/238
https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/pull/218

Do not merge until https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/pull/218 and https://github.com/cloudfoundry/bosh/pull/1732 are merged.