### PR TITLE
CPI API V1: Remove broken links

### DIFF
--- a/cpi-api-v1.html.md.erb
+++ b/cpi-api-v1.html.md.erb
@@ -323,8 +323,6 @@ After the Director received NotSupported error, it will delete the VM (via `dele
 
 No return value
 
-[Example configure_networks.go](https://github.com/cppforlife/bosh-warden-cpi-release/blob/master/src/github.com/cppforlife/bosh-warden-cpi/action/configure_networks.go)
-
 ---
 ### <a id="calculate-vm-cloud-properties"></a> `calculate_vm_cloud_properties` (Experimental)
 
@@ -363,8 +361,6 @@ If a parameter is set to a value greater than what is available (e.g. 1024 CPUs)
 #### Returned
 
 - **cloud_properties** [Hash]: an IaaS-specific set of cloud properties that define the size of the VM.
-
-[Example configure_networks.go](https://github.com/cppforlife/bosh-warden-cpi-release/blob/master/src/github.com/cppforlife/bosh-warden-cpi/action/configure_networks.go)
 
 ---
 ## <a id="disk"></a> Disk management


### PR DESCRIPTION
The `configure_networks` and `calculate_vm_cloud_properties` sections were linking to a non-existent Go example. 