### PR TITLE
Document precedence of OpenStack security groups

### DIFF
--- a/openstack-cpi.html.md.erb
+++ b/openstack-cpi.html.md.erb
@@ -25,7 +25,7 @@ azs:
 Schema for `cloud_properties` section used by dynamic network or manual network subnet:
 
 * **net_id** [String, required]: Network ID containing the subnet in which the instance will be created. Example: `net-b98ab66e-6fae-4c6a-81af-566e630d21d1`.
-* **security_groups** [Array, optional]: Array of security groups to apply for all VMs that are placed on this network. Defaults to security groups specified by `default_security_groups` in the global CPI settings unless security groups are specified on a resource pool for a VM. Security groups can be specified either on a resource pool or on a network.
+* **security_groups** [Array, optional]: Array of security groups to apply for all VMs that are placed on this network. Defaults to security groups specified by `default_security_groups` in the global CPI settings unless security groups are specified on a resource pool/vm type for a VM. If security groups are specified on a resource pool and a network, the resource pool security groups takes precedence since CPI v34+. In older CPI versions prior v34, security groups can either be specified for a network or a resource pool.
 
 Example of manual network:
 
@@ -66,7 +66,7 @@ Schema for `cloud_properties` section:
 
 * **instance_type** [String, required]: Type of the instance. Example: `m1.small`.
 * **availability_zone** [String, required]: Availability zone to use for creating instances. Example: `east`.
-* **security_groups** [Array, optional]: Array of security groups to apply for all VMs that are in this resource pool. Defaults to security groups specified by `default_security_groups` in the global CPI settings unless security groups are specified on one of the VM networks. Security groups can be specified either on a resource pool or on a network. Available in v16+.
+* **security_groups** [Array, optional]: Array of security groups to apply for all VMs that are in this resource pool. Defaults to security groups specified by `default_security_groups` in the global CPI settings unless security groups are specified on one of the VM networks. If security groups are specified on a resource pool and a network, the resource pool security groups takes precedence since CPI v34+. In older CPI versions prior v34, security groups can either be specified for a network or a resource pool.
 * **key_name** [String, optional]: Key pair name. Defaults to key pair name specified by `default_key_name` in the global CPI settings. Example: `bosh`.
 * **scheduler_hints** [Hash, optional]: Data passed to the OpenStack Filter scheduler to influence its decision where new VMs can be placed. See [VM Anti-Affinity](vm-anti-affinity.html#openstack) for a detailed example. Example: `{ group: af09abf2-2283... }`
 * **root_disk** [Hash, optional]: Custom root disk properties. Requires [`boot_from_volume: true`](https://bosh.io/jobs/openstack_cpi?source=github.com/cloudfoundry-incubator/bosh-openstack-cpi-release#p=openstack.boot_from_volume) to enable cinder-backed boot volumes. Available in v25+.


### PR DESCRIPTION
This should only be merged if OpenStack CPI version 34 is released.

[#150133075](https://www.pivotaltracker.com/story/show/150133075)

Signed-off-by: Tom Kiemes <tom.kiemes@sap.com>