### PR TITLE
Escape underbars to prevent italics

### DIFF
--- a/variable-types.html.md.erb
+++ b/variable-types.html.md.erb
@@ -95,4 +95,4 @@ variables:
 
 * **private_key** [String]: Private key (PEM encoded).
 * **public_key** [String]: Public key (PEM encoded).
-* **public_key_fingerprint** [String]: Public key's MD5 fingerprint. Example: `c3:ae:51:ec:cb:a8:09:ac:43:fd:84:dd:11:dd:fe:c7`.
+* **public\_key_\fingerprint** [String]: Public key's MD5 fingerprint. Example: `c3:ae:51:ec:cb:a8:09:ac:43:fd:84:dd:11:dd:fe:c7`.


### PR DESCRIPTION
Work around idiosyncrasy in markdown parser
that renders this as italics on bosh.io/docs