### PR TITLE
Fix typo in bosh-lite deploy docs

### DIFF
--- a/bosh-lite.html.md.erb
+++ b/bosh-lite.html.md.erb
@@ -68,7 +68,7 @@ Follow below steps to get it running on locally on VirtualBox:
 
     <pre class="terminal">
     $ bosh -e vbox env
-    Using environment '192.168.56.6' as '?'
+    Using environment '192.168.50.6' as '?'
 
     Name: ...
     User: admin


### PR DESCRIPTION
Signed-off-by: Will Pragnell <wpragnell@pivotal.io>