### PR TITLE
Fix markup on the Jumpbox page

### DIFF
--- a/jumpbox.html.md.erb
+++ b/jumpbox.html.md.erb
@@ -13,5 +13,5 @@ To obtain SSH access specifically to the Director VM when necessary you can opt 
 <pre class="terminal">
 $ bosh int creds.yml --path /jumpbox_ssh/private_key > jumpbox.key
 $ chmod 600 jumpbox.key
-$ ssh jumpbox@<external-or-internal-ip> -i jumpbox.key
+$ ssh jumpbox@&lt;external-or-internal-ip&gt; -i jumpbox.key
 </pre>


### PR DESCRIPTION
The `<external-or-internal-ip>` placeholder is not showing up as it gets misinterpreted as an HTML tag by the browser. Using good old HTML entities fixes the problem.