### PR TITLE
Change director_name to Bosh-Lite-Director

### DIFF
--- a/bosh-lite.html.md.erb
+++ b/bosh-lite.html.md.erb
@@ -49,7 +49,7 @@ Follow below steps to get it running on locally on VirtualBox:
       -o ~/workspace/bosh-deployment/bosh-lite-runc.yml \
       -o ~/workspace/bosh-deployment/jumpbox-user.yml \
       --vars-store ./creds.yml \
-      -v director_name="bosh-1" \
+      -v director_name="bosh-lite" \
       -v internal_ip=192.168.50.6 \
       -v internal_gw=192.168.50.1 \
       -v internal_cidr=192.168.50.0/24 \

--- a/bosh-lite.html.md.erb
+++ b/bosh-lite.html.md.erb
@@ -49,7 +49,7 @@ Follow below steps to get it running on locally on VirtualBox:
       -o ~/workspace/bosh-deployment/bosh-lite-runc.yml \
       -o ~/workspace/bosh-deployment/jumpbox-user.yml \
       --vars-store ./creds.yml \
-      -v director_name="Bosh-Lite-Director" \
+      -v director_name="bosh-1" \
       -v internal_ip=192.168.50.6 \
       -v internal_gw=192.168.50.1 \
       -v internal_cidr=192.168.50.0/24 \

--- a/bosh-lite.html.md.erb
+++ b/bosh-lite.html.md.erb
@@ -49,7 +49,7 @@ Follow below steps to get it running on locally on VirtualBox:
       -o ~/workspace/bosh-deployment/bosh-lite-runc.yml \
       -o ~/workspace/bosh-deployment/jumpbox-user.yml \
       --vars-store ./creds.yml \
-      -v director_name="Bosh Lite Director" \
+      -v director_name="Bosh-Lite-Director" \
       -v internal_ip=192.168.50.6 \
       -v internal_gw=192.168.50.1 \
       -v internal_cidr=192.168.50.0/24 \


### PR DESCRIPTION
Update command to create BOSH lite environment to use a director name without spaces; `Bosh-Lite-Director` instead of `Bosh Lite Director`. Director name with space results in cryptic error messages when using the config server. The director generated fully-qualified-variable-name will contain spaces and as a result, will fail director validation of variable names.

Ref: https://github.com/cloudfoundry/bosh/blob/master/src/bosh-director/lib/bosh/director/config_server/config_server_helper.rb#L42