### PR TITLE
Add dashes to bosh-lite example director name

### DIFF
--- a/bosh-lite.html.md.erb
+++ b/bosh-lite.html.md.erb
@@ -49,7 +49,7 @@ Follow below steps to get it running on locally on VirtualBox:
       -o ~/workspace/bosh-deployment/bosh-lite-runc.yml \
       -o ~/workspace/bosh-deployment/jumpbox-user.yml \
       --vars-store ./creds.yml \
-      -v director_name="Bosh Lite Director" \
+      -v director_name="Bosh-Lite-Director" \
       -v internal_ip=192.168.50.6 \
       -v internal_gw=192.168.50.1 \
       -v internal_cidr=192.168.50.0/24 \


### PR DESCRIPTION
A director name with spaces will break the config server, if you happen
to want to deploy that. It doesn't seem like the name of this director
is used elsewhere, so we can just add dashes.

Signed-off-by: Jesse Malone <jmalone@pivotal.io>