### PR TITLE
Small corrections to cli-ops-files.html.md.erb

### DIFF
--- a/cli-ops-files.html.md.erb
+++ b/cli-ops-files.html.md.erb
@@ -270,23 +270,6 @@ items:
 
 ```yaml
 - type: replace
-  path: /items/name=item7/count
-  value: 10
-```
-
-- finds array item with matching key `name` with value `item7`
-- adds `count` key as a sibling of name, resulting in:
-
-  ```yaml
-  ...
-  items:
-  - name: item7
-    count: 10
-  - name: item8
-  ```
-
-```yaml
-- type: replace
   path: /items/name=item8/count
   value: 10
 ```
@@ -325,10 +308,10 @@ items:
   ```yaml
   ...
   items:
-  - name: item5
   - name: item6
   - name: item7
-    count: 10
+  - name: item8
+  - name: item8
   ```
 
 ---


### PR DESCRIPTION
```
- type: replace
  path: /items/name=item7/count
  value: 10
```

results in error (using CLI v. 2.0.44): 

> Expected to find a map key 'count' for path '/items/name=item7/count' (found map keys: 'name')


Alternatively, we could add a '?' to the end of 'count'.