### PR TITLE
max_in_flight can be set as percentage

### DIFF
--- a/deployment-manifest.html.md.erb
+++ b/deployment-manifest.html.md.erb
@@ -219,7 +219,7 @@ compilation:
 **update** [Hash, required]: This specifies instance update properties. These properties control how BOSH updates job instances during the deployment.
 
 * **canaries** [Integer, required]: The number of [canary](./terminology.html#canary) instances.
-* **max\_in\_flight** [Integer, required]: The maximum number of non-canary instances to update in parallel.
+* **max\_in\_flight** [Integer or Percentage, required]: The maximum number of non-canary instances to update in parallel.
 * **canary\_watch\_time** [Integer or Range, required]
     * If the `canary_watch_time` is an integer, the Director sleeps for that many milliseconds, then checks whether the canary instances are healthy.
     * If the `canary_watch_time` is a range (low-high), the Director:

--- a/manifest-v2.html.md.erb
+++ b/manifest-v2.html.md.erb
@@ -104,7 +104,7 @@ stemcells:
 **update** [Hash, required]: This specifies instance update properties. These properties control how BOSH updates instances during the deployment.
 
 * **canaries** [Integer, required]: The number of [canary](./terminology.html#canary) instances.
-* **max\_in\_flight** [Integer, required]: The maximum number of non-canary instances to update in parallel.
+* **max\_in\_flight** [Integer or Percentage, required]: The maximum number of non-canary instances to update in parallel.
 * **canary\_watch\_time** [Integer or Range, required]: Only applies to monit start operation.
     * If the `canary_watch_time` is an integer, the Director sleeps for that many milliseconds, then checks whether the canary instances are healthy.
     * If the `canary_watch_time` is a range (low-high), the Director:


### PR DESCRIPTION
Discovered here https://docs.cloudfoundry.org/adminguide/diego-cell-upgrade.html.

Using percentage we can avoid the following:
```
+    update:
+      max_in_flight: (( calc "ceil(jobs.cell_stg_z1.instances / 2)" ))
```
And put this instead:
```
+    update:
+      max_in_flight: 50%
```