### PR TITLE
Escape key for property persistent_disk_type

### DIFF
--- a/manifest-v2.html.md.erb
+++ b/manifest-v2.html.md.erb
@@ -149,7 +149,7 @@ update:
 * **vm_resources** [Hash, optional]: Specifies generic VM resources such as CPU, RAM and disk size that are automatically translated into correct VM cloud properties to determine VM size. VM size is determined on best effort basis as some IaaSes may not support exact size configuration. Currently some CPIs (Google and Azure) do not support this functionality. Available in bosh-release v264+.
   * **cpu** [Integer, required]: Number of CPUs.
   * **ram** [Integer, required]: Amount of RAM.
-  * **ephemeral_disk_size** [Integer, required]: Ephemeral disk size.
+  * **ephemeral\_disk\_size** [Integer, required]: Ephemeral disk size.
 * **stemcell** [String, required]: A valid stemcell alias from the Stemcells Block.
 * **persistent\_disk\_type** [String, optional]: A valid disk type name from the cloud config. [Read more about persistent disks](./persistent-disks.html)
 * **networks** [Array, required]: Specifies the networks this instance requires. Each network can have the following properties specified:


### PR DESCRIPTION
persistent_disk_type was not escaped in the manifest-v2 schema. This change means the underscores will appear correctly.

Signed-off-by: Iain Sproat <isproat@pivotal.io>