### PR TITLE
Add documentation about missing vm configs in compilation block

### DIFF
--- a/cloud-config.html.md.erb
+++ b/cloud-config.html.md.erb
@@ -242,7 +242,7 @@ The Director creates compilation VMs for release compilation. The Director will 
 
 * **workers** [Integer, required]: The maximum number of compilation VMs.
 * **az** [String, required]: Name of the AZ defined in AZs section to use for creating compilation VMs.
-* **vm_type** [String, required]: Name of the VM type defined in VM types section to use for creating compilation VMs. Alternatively you can specify the `vm_resources`, or `cloud_properties` key.
+* **vm_type** [String, optional]: Name of the VM type defined in VM types section to use for creating compilation VMs. Alternatively, you can specify the `vm_resources`, or `cloud_properties` key.
 * **vm_resources** [Hash, optional]: Specifies generic VM resources such as CPU, RAM and disk size that are automatically translated into correct VM cloud properties to determine VM size. VM size is determined on best effort basis as some IaaSes may not support exact size configuration. Currently some CPIs (Google and Azure) do not support this functionality. Available in bosh-release v264+.
 * **cloud_properties** [Hash, optional]: Describes any IaaS-specific properties needed to create VMs. Most IaaSes require this. Examples: `instance_type`, `availability_zone`. Default is `{}` (empty Hash).
 * **network** [String, required]: References a valid network name defined in the Networks block. BOSH assigns network properties to compilation VMs according to the type and properties of the specified network.

--- a/cloud-config.html.md.erb
+++ b/cloud-config.html.md.erb
@@ -242,7 +242,9 @@ The Director creates compilation VMs for release compilation. The Director will 
 
 * **workers** [Integer, required]: The maximum number of compilation VMs.
 * **az** [String, required]: Name of the AZ defined in AZs section to use for creating compilation VMs.
-* **vm_type** [String, required]: Name of the VM type defined in VM types section to use for creating compilation VMs.
+* **vm_type** [String, required]: Name of the VM type defined in VM types section to use for creating compilation VMs. Alternatively you can specify the `vm_resources`, or `cloud_properties` key.
+* **vm_resources** [Hash, optional]: Specifies generic VM resources such as CPU, RAM and disk size that are automatically translated into correct VM cloud properties to determine VM size. VM size is determined on best effort basis as some IaaSes may not support exact size configuration. Currently some CPIs (Google and Azure) do not support this functionality. Available in bosh-release v264+.
+* **cloud_properties** [Hash, optional]: Describes any IaaS-specific properties needed to create VMs. Most IaaSes require this. Examples: `instance_type`, `availability_zone`. Default is `{}` (empty Hash).
 * **network** [String, required]: References a valid network name defined in the Networks block. BOSH assigns network properties to compilation VMs according to the type and properties of the specified network.
 * **reuse\_compilation\_vms** [Boolean, optional]: If `false`, BOSH creates a new compilation VM for each new package compilation and destroys the VM when compilation is complete. If `true`, compilation VMs are re-used when compiling packages. Defaults to `false`.
 


### PR DESCRIPTION
Maximum one of vm_type, vm_resources, or cloud_properties is allowed to be specified.

[#151750562](https://www.pivotaltracker.com/story/show/151750562)