### PR TITLE
Correct typo: flag --n should be -n

### DIFF
--- a/cli-global-flags.html.md.erb
+++ b/cli-global-flags.html.md.erb
@@ -37,7 +37,7 @@ CLI does not provide a way to specify UAA user login information since all non-i
 ---
 ## <a id="output"></a> Output flags
 
-- `--n` flag affirms any confirmation that typically requires use input (`BOSH_NON_INTERACTIVE=true` environment variable)
+- `-n` flag affirms any confirmation that typically requires use input (`BOSH_NON_INTERACTIVE=true` environment variable)
 - `--json` flag changes output format to JSON
 - `--tty` flag forces output to include all decorative text typically visible when command is not redirected
 - `--no-color` flag disables colors (enabled by default when command is redirected)


### PR DESCRIPTION
The flag for affirming any confirmation that typically requires use input, is listed as --n, when it should be -n