### PR TITLE
Fix documentation for SSH variable type

### DIFF
--- a/variable-types.html.md.erb
+++ b/variable-types.html.md.erb
@@ -94,5 +94,5 @@ variables:
 **<value>** [Hash]: SSH key. When generated defaults to RSA 2048 bits.
 
 * **private_key** [String]: Private key (PEM encoded).
-* **public_key** [String]: Public key (PEM encoded).
+* **public_key** [String]: Public key (OpenSSH format, "ssh-rsa ...").
 * **public\_key\_fingerprint** [String]: Public key's MD5 fingerprint. Example: `c3:ae:51:ec:cb:a8:09:ac:43:fd:84:dd:11:dd:fe:c7`.


### PR DESCRIPTION
I wasn't able to validate this as I'm still using BOSH v1 at the moment but from the Concourse documentation it seems an SSH variable's public key will be generated in OpenSSH format and not PEM encoded.

If my assumption is right then please review and merge this PR.