### PR TITLE
Added windows scp examples

### DIFF
--- a/cli-v2.html.md.erb
+++ b/cli-v2.html.md.erb
@@ -844,11 +844,13 @@ See [CPI config](cpi-config.html).
     $ bosh -e vbox -d cf scp ~/Downloads/script.sh :/tmp/script.sh
     $ bosh -e vbox -d cf scp ~/Downloads/script.sh diego-cell:/tmp/script.sh
     $ bosh -e vbox -d cf scp ~/Downloads/script.sh diego-cell/209c42e5-3c1a-432a-8445-ab8d7c9f69b0:/tmp/script.sh
+    $ bosh -e vbox -d cf scp ~/Downloads/script.ps1 windows_diego_cell:c:/temp/script/script.ps1
 
     # copy file from remote machines in a deployment to this machine
     $ bosh -e vbox -d cf scp :/tmp/script.sh ~/Downloads/script.sh
     $ bosh -e vbox -d cf scp diego-cell:/tmp/script.sh ~/Downloads/script.sh
     $ bosh -e vbox -d cf scp diego-cell/209c42e5-3c1a-432a-8445-ab8d7c9f69b0:/tmp/script.sh ~/Downloads/script.sh
+    $ bosh -e vbox -d cf scp windows_diego_cell:c:/temp/script/script.ps1:~/Downloads/script.ps1
 
     # copy files from each instance into instance specific local directory
     $ bosh -e vbox -d cf scp diego-cell:/tmp/logs/ /tmp/logs/((instance_id))


### PR DESCRIPTION
Couldn't find any examples for secure copy to windows diego cells.  Think these might be helpful to other members of the community.  Wasn't sure if I should have put them in their own section, so I just appended them to the existing examples.