### PR TITLE
Update hyperlink for dns-release

### DIFF
--- a/dns.html.md.erb
+++ b/dns.html.md.erb
@@ -49,7 +49,7 @@ Since BOSH DNS is automatically managed, DNS addresses are not meant to be const
 ---
 ## <a id='dns-release'></a> DNS release
 
-To take advantage of native DNS functionality, it's expected that [DNS release](https://bosh.io/releases/github.com/cloudfoundry/dns-release?all=1) runs on each VM. We recommend to colocate DNS release by definiting it in an [addon](runtime-config.html#addons).
+To take advantage of native DNS functionality, it's expected that [DNS release](https://bosh.io/releases/github.com/cloudfoundry/bosh-dns-release?all=1) runs on each VM. We recommend to colocate DNS release by definiting it in an [addon](runtime-config.html#addons).
 
 DNS release provides two jobs: `bosh-dns` (for Linux) and `bosh-dns-windows` (for Windows) which start a simple DNS server bound to a [link local address](https://bosh.io/jobs/bosh-dns?source=github.com/cloudfoundry/bosh-dns-release#p=address).
 


### PR DESCRIPTION
The hyperlink to dns-release was incorrect and needed to be changed to bosh-dns-release. Fixes https://github.com/cloudfoundry/docs-bosh/issues/446