### PR TITLE
Escape underscores for aws_key_arn

### DIFF
--- a/aws-cpi.html.md.erb
+++ b/aws-cpi.html.md.erb
@@ -91,7 +91,7 @@ Schema for `cloud_properties` section:
         * Only valid for `io1` type drive.
         * Required when `io1` type drive is specified.
     * **encrypted** [Boolean, optional] Enables encryption for the EBS backed ephemeral disk. An error is raised, if the `instance_type` does not support it. Since v53. Defaults to `false`. Overrides the global `encrypted` property.
-    * **kms_key_arn** [String, optional] The ARN of an Amazon KMS key to use when encrypting the disk. 
+    * **kms\_key\_arn** [String, optional] The ARN of an Amazon KMS key to use when encrypting the disk.
     * **use\_instance\_storage** [Boolean, optional] Forces the usage of instance storage as ephemeral disk backing. Will raise an error, if the used `instance_type` does not have instance storage. Cannot be combined with any other option under `ephemeral_disk` or with `raw_instance_storage`. Since v53. Defaults to `false`.
 * **root_disk** [Hash, optional]: EBS backed root disk of custom size.
     * **size** [Integer, required]: Specifies the disk size in megabytes.

--- a/repack-stemcell.html.md.erb
+++ b/repack-stemcell.html.md.erb
@@ -43,7 +43,7 @@ The `repack-stemcell` command can be used to enable the encryption of the root f
 Two arguments enable the encryption of the root filesystem:
 
 * **encrypted** [Boolean, optional]: Must be set to `true` if encryption of the root filesystem
-* **kms_key_arn** [String, optional]: Created in the [Encryption Keys](https://console.aws.amazon.com/iam/home#encryptionKeys) section of the Identity and Access Management (IAM) console. If not specified _and_ `encrypted` is true, the root filesystem will be encrypted with the default key.
+* **kms\_key\_arn** [String, optional]: Created in the [Encryption Keys](https://console.aws.amazon.com/iam/home#encryptionKeys) section of the Identity and Access Management (IAM) console. If not specified _and_ `encrypted` is true, the root filesystem will be encrypted with the default key.
 
 We modify the cloud-properties of an AWS stemcell to encrypt the root filesystem of instances deployed with our repacked stemcell. The cloud-properties must be specified as valid JSON. This only works with heavy stemcells:
 


### PR DESCRIPTION
We noticed the keys looked a little off in the docs and FTFY