### PR TITLE
Document how the 'drain' script can catch a 'scale-in' condition

### DIFF
--- a/content/drain.md
+++ b/content/drain.md
@@ -57,7 +57,39 @@ Drain script can access the following environment variables:
 * `BOSH_JOB_STATE`: JSON description of the current job state
 * `BOSH_JOB_NEXT_STATE`: JSON description of the new job state that is being applied
 
-For example drain script can use this feature to determine if the size of the persistent disk changes and take a specified action.
+Currently, only persistent disk size is provided in those two variables. For
+example:
+
+```json
+{"persistent_disk":2048}
+```
+
+With this, the `drain` script can determine when the size of the persistent
+disk changes and take action.
+
+But more importantly, it can detect when the current node is being deleted.
+This is important when the node is part of a cluster and needs to gracefully
+say goodbye to its pairs before leaving forever.
+
+When the drain script is run before the node is deleted, then the new
+persistent disk size is zero. For exemple, you would be able to see these
+values when `echo`ing them.
+
+```bash
+$ cat /var/vcap/jobs/my-job/bon/drain
+(
+  echo BOSH_JOB_STATE=$BOSH_JOB_STATE
+  echo BOSH_JOB_NEXT_STATE=$BOSH_JOB_NEXT_STATE
+) \
+  > /var/vcap/sys/log/my-job/drain.stdout.log
+$ cat /var/vcap/sys/log/my-job/drain.stdout.log
+BOSH_JOB_STATE={"persistent_disk":2048}
+BOSH_JOB_NEXT_STATE={"persistent_disk":0}
+```
+
+You'll find [here](https://github.com/cloudfoundry-incubator/cfcr-etcd-release/blob/master/jobs/etcd/templates/bin/drain.erb)
+an exemple script for an etcd member to leave its etcd cluster gracefully.
+
 
 ---
 ## Logs {: #logs }


### PR DESCRIPTION
Hi there,

Live from User Day in Boston, here is an improvement on the `drain` script documentation.

When a node is being permanently deleted, the `drain` script sometimes has to take action so that the current node leaves its cluster gracefully.

This PR documents how to do that.

Cheers