### PR TITLE
Update manifest to v2

### DIFF
--- a/content/vm-struct.md
+++ b/content/vm-struct.md
@@ -9,9 +9,9 @@ Each BOSH managed VM may be assigned a single copy of a deployment job to run. A
 When the assignment is made, the Agent will populate `/var/vcap/` directory with the release jobs specified in the deployment job definition in the deployment manifest. If selected release jobs depend on release packages those will also be downloaded and placed into the `/var/vcap` directory. For example given a following deployment job definition:
 
 ```yaml
-jobs:
+instance_groups:
 - name: redis-master
-  templates:
+  jobs:
   - {name: redis-server, release: redis}
   - {name: syslog-forwarder, release: syslog}
   ...


### PR DESCRIPTION
We're just following some onboarding docs and there was a discrepancy between the v2 example and these docs which seem to be out of date. I'm not sure if this change should be made or if we should be linking to a separate v2 docs page in our onboarding.

Also unsure if all references to "job(s)" should now be references to "instance group(s)" or not.