### PR TITLE
Add IaaS-specific summaries?

### DIFF
--- a/content/aws.md
+++ b/content/aws.md
@@ -1,0 +1,63 @@
+---
+title: Amazon Web Services
+---
+
+# Amazon Web Services
+
+The `aws` CPI can be used with [Amazon Web Services](https://aws.amazon.com/).
+
+ * Release: [cloudfoundry-incubator/bosh-aws-cpi-release](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release)
+ * Issues: [GitHub Issues](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/issues)
+ * Slack: [cloudfoundry#bosh](https://cloudfoundry.slack.com/messages/bosh)
+
+
+## Concepts
+
+The following table maps BOSH concepts to their AWS-native equivalents.
+
+| BOSH              | Amazon Web Services |
+| ----------------- | ------------------- |
+| Availability Zone | [Availability Zone](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html) |
+| Virtual Machine   | [EC2 Instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Instances.html) |
+| Network Subnet    | [VPC Subnet](https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html) |
+| Virtual IP        | [EC2 Elastic IP](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html) |
+| Persistent Disk   | [EC2 EBS Volume](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumes.html) |
+| Disk Snapshot     | [EC2 EBS Snapshot](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSSnapshots.html) |
+| Stemcell          | [EC2 Amazon Machine Image](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) |
+
+
+## Feature Support
+
+
+### Network
+
+The AWS CPI does not currently support multiple NICs being attached to a VM.
+
+| Network Type | Support |
+| ------------ | ------- |
+| Manual       | Single network per instance |
+| Dynamic      | Single network per instance |
+| VIP          | Single network per instance |
+
+
+### Encryption
+
+AWS supports encryption functionality through their [Key Management Service](https://aws.amazon.com/kms/) using both IaaS-managed or customer-managed keys. The `encrypted` and `kms_key_arn` settings can be set globally, or for specific disks and stemcells, to configure encryption settings.
+
+| Platform | Disk Type       | Encryption | Customer-managed Keys |
+| -------- | --------------- | ---------- | --------------------- |
+| Linux    | Root Disk       | Supported, [v69](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/releases/tag/v69)+ | Supported |
+| Linux    | Ephemeral Disk  | Supported, [v69](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/releases/tag/v69)+ | Supported |
+| Linux    | Persistent Disk | Supported, [v69](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/releases/tag/v69)+ | Supported |
+| Windows  | Root Disk       | Partially Supported (manual steps required) | n/a |
+| Windows  | Ephemeral Disk  | Not Supported | n/a |
+| Windows  | Persistent Disk | Not Supported | n/a |
+
+**Key Rotation** - since the CPI does not have insight into keys being rotated within AWS Console or `aws` CLI commands, it is typically easiest to rotate keys by provisioning a new key and updating cloud properties to refer to the new ARN. Since cloud properties for a disk change, BOSH will create a new disk using the new key and migrate data onto the new disk.
+
+
+### Miscellaneous
+
+| Feature   | Support |
+| --------- | ------- |
+| Multi-CPI | Supported, [v61](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/releases/tag/v61)+ |

--- a/content/azure.md
+++ b/content/azure.md
@@ -1,0 +1,72 @@
+---
+title: Microsoft Azure
+---
+
+# Microsoft Azure
+
+The `azure` CPI can be used with [Microsoft Azure](https://azure.microsoft.com/).
+
+ * Release: [cloudfoundry-incubator/bosh-azure-cpi-release](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release)
+ * Issues: [GitHub Issues](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/issues)
+ * Slack: [cloudfoundry#bosh-azure-cpi](https://cloudfoundry.slack.com/messages/bosh-azure-cpi)
+
+
+## Concepts
+
+The following table maps BOSH concepts to their Azure-native equivalents.
+
+| BOSH              | Microsoft Azure |
+| ----------------- | --------------- |
+| Availability Zone | [Availability Zone](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) |
+| Virtual Machine   | [Virtual Machine](https://docs.microsoft.com/en-us/azure/virtual-machines/linux/sizes) |
+| Network Subnet    | [Virtual Network Subnet](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-overview) |
+| Virtual IP        | [Public IP](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-ip-addresses-overview-arm#public-ip-addresses) |
+| Persistent Disk   | [Disk Storage](https://azure.microsoft.com/en-us/services/storage/disks/) and [Managed Disks](https://azure.microsoft.com/en-us/services/managed-disks/) |
+| Disk Snapshot     | [Managed Disk Snapshot](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/managed-disks-overview#managed-disk-snapshots) |
+| Stemcell          |  |
+
+
+## Feature Support
+
+
+### Network
+
+| Network Type | Support |
+| ------------ | ------- |
+| Manual       | Multiple networks per instance |
+| Dynamic      | Multiple networks per instance |
+| VIP          | Single network per instance |
+
+
+### Encryption
+
+
+#### Managed Disks
+
+When using Managed Disks, encryption is automatically used by all disks and cannot be disabled. All aspects of the encryption are internally managed by Azure.
+
+| Disk Type       | Encryption | Customer-managed Keys |
+| --------------- | ---------- | --------------------- |
+| Root Disk       | Required, default | Not Supported |
+| Ephemeral Disk  | Required, default | Not Supported |
+| Persistent Disk | Required, default | Not Supported |
+
+
+#### Storage Accounts
+
+When using Storage Accounts, encryption keys can be managed through the [Azure Key Vault](https://azure.microsoft.com/en-us/services/key-vault/) to ensure disks are encrypted. There are no specific properties which need to be configured through CPI configuration.
+
+| Disk Type       | Encryption | Customer-managed Keys |
+| --------------- | ---------- | --------------------- |
+| Root Disk       | Required, default | Supported |
+| Ephemeral Disk  | Required, default | Supported |
+| Persistent Disk | Required, default | Supported |
+
+**Key Rotation** - encryption keys can be configured and rotated from within the Azure Portal ([learn more](https://docs.microsoft.com/en-us/azure/security/azure-security-disk-encryption)), and Azure transparently handles re-encryption of data.
+
+
+### Miscellaneous
+
+| Feature   | Support |
+| --------- | ------- |
+| Multi-CPI | Not Supported |

--- a/content/google.md
+++ b/content/google.md
@@ -1,0 +1,45 @@
+---
+title: Google Cloud Platform
+---
+
+# Google Cloud Platform
+
+The `google` CPI can be used with [Google Cloud Platform](https://cloud.google.com/).
+
+ * Release: [cloudfoundry-incubator/bosh-google-cpi-release](https://github.com/cloudfoundry-incubator/bosh-google-cpi-release)
+ * Issues: [GitHub Issues](https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/issues)
+ * Slack: [cloudfoundry#bosh-gce-cpi](https://cloudfoundry.slack.com/messages/bosh-gce-cpi)
+
+
+## Concepts
+
+The following table maps BOSH concepts to their respective IaaS concept.
+
+| BOSH              | Google Cloud Platform |
+| ----------------- | --------------------- |
+| Availability Zone | [Zone](https://cloud.google.com/compute/docs/regions-zones/) |
+| Virtual Machine   | [Virtual Machine Instance](https://cloud.google.com/compute/docs/instances/) |
+| Network Subnet    | [VPC Subnet](https://cloud.google.com/vpc/docs/vpc#vpc_networks_and_subnets) |
+| Virtual IP        | [Static External IP](https://cloud.google.com/compute/docs/ip-addresses/#reservedaddress) |
+| Persistent Disk   | [Persistent Disks](https://cloud.google.com/persistent-disk/) |
+| Disk Snapshot     | [Persistent Disk Snapshots](https://cloud.google.com/compute/docs/disks/create-snapshots) |
+| Stemcell          |  |
+
+
+## Feature Support
+
+
+### Network
+
+| Network Type | Support |
+| ------------ | ------- |
+| Manual       | Single network per instance |
+| Dynamic      | Single network per instance |
+| VIP          | Single network per instance |
+
+
+### Miscellaneous
+
+| Feature   | Support |
+| --------- | ------- |
+| Multi-CPI | Not Supported |

--- a/content/openstack.md
+++ b/content/openstack.md
@@ -1,0 +1,68 @@
+---
+title: OpenStack
+---
+
+# OpenStack
+
+The `openstack` CPI can be used with [OpenStack](https://azure.microsoft.com/).
+
+ * Release: [cloudfoundry-incubator/bosh-openstack-cpi-release](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release)
+ * Issues: [GitHub Issues](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release/issues)
+ * Slack: [cloudfoundry#bosh-azure-cpi](https://cloudfoundry.slack.com/messages/bosh-azure-cpi)
+
+
+## Requirements
+
+An OpenStack environment running one of the following supported releases:
+
+ * [Liberty](http://www.openstack.org/software/liberty) (actively tested)
+ * [Mitaka](http://www.openstack.org/software/mitaka) (actively tested)
+ * [Newton](http://www.openstack.org/software/newton) (actively tested)
+
+    !!! tip
+        Juno has a [bug](https://bugs.launchpad.net/nova/+bug/1396854) that prevents BOSH to assign specific IPs to VMs. You have to apply a Nova patch to avoid this problem.
+
+And the following OpenStack services:
+
+ * [Identity](https://www.openstack.org/software/releases/ocata/components/keystone):
+   BOSH authenticates credentials and retrieves the endpoint URLs for other OpenStack services.
+ * [Compute](https://www.openstack.org/software/releases/ocata/components/nova):
+   BOSH boots new VMs, assigns floating IPs to VMs, and creates and attaches volumes to VMs.
+ * [Image](https://www.openstack.org/software/releases/ocata/components/glance):
+   BOSH stores stemcells using the Image service.
+ * *(Optional)* [OpenStack Networking](https://www.openstack.org/software/releases/ocata/components/neutron):
+   Provides network scaling and automated management functions that are useful when deploying complex distributed systems. **Note:** OpenStack networking is used as default as of v28 of the OpenStack CPI. To disable the use of the OpenStack Networking project, see [using nova-networking](openstack-nova-networking.md).
+
+
+## Concepts
+
+The following table maps BOSH concepts to their OpenStack-native equivalents.
+
+| BOSH              | OpenStack |
+| ----------------- | --------- |
+| Availability Zone |  |
+| Virtual Machine   |  |
+| Network Subnet    |  |
+| Virtual IP        |  |
+| Persistent Disk   |  |
+| Disk Snapshot     |  |
+| Stemcell          |  |
+
+
+## Feature Support
+
+
+### Network
+
+| Network Type | Support |
+| ------------ | ------- |
+| Manual       | Multiple networks per instance |
+| Dynamic      | Single network per instance |
+| VIP          | Single network per instance |
+
+
+### Miscellaneous
+
+| Feature   | Support |
+| --------- | ------- |
+| Multi-CPI | Supported, [v31](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release/releases/tag/v31)+ |

--- a/content/vcloud.md
+++ b/content/vcloud.md
@@ -1,0 +1,45 @@
+---
+title: VMware vCloud
+---
+
+# VMware vCloud
+
+The `vcloud` CPI can be used with [VMware vCloud](https://www.vmware.com/products/vcloud-suite.html).
+
+ * Release: [cloudfoundry-incubator/bosh-vcloud-cpi-release](https://github.com/cloudfoundry-incubator/bosh-vcloud-cpi-release)
+ * Issues: [GitHub Issues](https://github.com/cloudfoundry-incubator/bosh-vcloud-cpi-release/issues)
+ * Slack: [cloudfoundry#bosh](https://cloudfoundry.slack.com/messages/bosh)
+
+
+## Concepts
+
+The following table maps BOSH concepts to their respective IaaS concept.
+
+| BOSH              | Google Cloud Platform |
+| ----------------- | --------------------- |
+| Availability Zone |  |
+| Virtual Machine   |  |
+| Network Subnet    |  |
+| Virtual IP        |  |
+| Persistent Disk   |  |
+| Disk Snapshot     |  |
+| Stemcell          |  |
+
+
+## Feature Support
+
+
+### Network
+
+| Network Type | Support |
+| ------------ | ------- |
+| Manual       | Multiple networks per instance |
+| Dynamic      | Not Supported |
+| VIP          | Not Supported |
+
+
+### Miscellaneous
+
+| Feature   | Support |
+| --------- | ------- |
+| Multi-CPI | Not Supported |

--- a/content/vsphere.md
+++ b/content/vsphere.md
@@ -1,0 +1,56 @@
+---
+title: VMware vSphere
+---
+
+# vSphere
+
+The `vsphere` CPI can be used with [VMware vSphere](https://www.vmware.com/products/vsphere.html).
+
+ * Release: [cloudfoundry-incubator/bosh-vsphere-cpi-release](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release)
+ * Issues: [GitHub Issues](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/issues)
+ * Slack: [cloudfoundry#bosh](https://cloudfoundry.slack.com/messages/bosh)
+
+
+## Concepts
+
+The following table maps BOSH concepts to their vSphere-native equivalents.
+
+| BOSH              | vSphere |
+| ----------------- | --------- |
+| Availability Zone |  |
+| Virtual Machine   |  |
+| Network Subnet    |  |
+| Virtual IP        |  |
+| Persistent Disk   |  |
+| Disk Snapshot     |  |
+| Stemcell          |  |
+
+
+## Feature Support
+
+
+### Network
+
+| Network Type | Support |
+| ------------ | ------- |
+| Manual       | Multiple networks per instance |
+| Dynamic      | Not Supported |
+| VIP          | Not Supported |
+
+
+### Encryption
+
+vSphere supports disk encryption and customer-managed keys when managed through policy configuration within the vCenter 6.5+ ([learn more](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.security.doc/GUID-047A06F6-DE3D-4428-998C-DAAE84A33316.html). For this functionality, encryption occurs at the hypervisor level which is transparent to the VM. Once enabled within vCenter, no additional configuration is required for the CPI.
+
+| Disk Type       | Encryption |
+| --------------- | ---------- |
+| Root Disk       | Supported |
+| Ephemeral Disk  | Supported |
+| Persistent Disk | Supported |
+
+
+### Miscellaneous
+
+| Feature   | Support |
+| --------- | ------- |
+| Multi-CPI | Not Supported |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -201,19 +201,23 @@ pages:
 
   - "--- Cloud Providers": divider.md
   - Amazon Web Services:
+    - Overview: aws.md
     - Usage: aws-cpi.md
     - Common Errors: aws-cpi-errors.md
     - IAM Users: aws-iam-users.md
     - IAM Profiles: aws-iam-instance-profiles.md
     - Using Instance Storage: aws-instance-storage.md
   - Google Cloud Platform:
+    - Overview: google.md
     - Usage: google-cpi.md
     - Required Permissions: google-required-permissions.md
   - Microsoft Azure:
+    - Overview: azure.md
     - Usage: azure-cpi.md
     - Common Errors: azure-cpi-errors.md
     - Creating Resources: azure-resources.md
   - OpenStack:
+    - Overview: openstack.md
     - Usage: openstack-cpi.md
     - Common Errors: openstack-cpi-errors.md
     - Using Auto-anti-affinity: openstack-auto-anti-affinity.md
@@ -231,8 +235,10 @@ pages:
   - VirtualBox:
     - Usage: virtualbox-cpi.md
   - VMware vCloud:
+    - Overview: vcloud.md
     - Usage: vcloud-cpi.md
   - VMware vSphere:
+    - Overview: vsphere.md
     - Usage: vsphere-cpi.md
     - Common Errors: vsphere-cpi-errors.md
     - Recovery from an ESXi Host Failure: vsphere-esxi-host-failure.md

--- a/theme/main.html
+++ b/theme/main.html
@@ -9,3 +9,14 @@
     </div>
   {% endif %}
 {% endblock %}
+
+{% block htmltitle %}
+  {% if page and page.meta and page.meta.title %}
+    {# always show site suffix to avoid individual content pages needing to suffix #}
+    <title>{{ page.meta.title }} - {{ config.site_name }}</title>
+  {% elif page and page.title and not page.is_homepage %}
+    <title>{{ page.title }} - {{ config.site_name }}</title>
+  {% else %}
+    <title>{{ config.site_name }}</title>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Content-wise, I was looking to have a place for CPI landing page to document their basic functionality (including new encryption info) and help bridge some of the core terms IaaSes deal with.

Specifically here...

 * provides entrypage and summary for basic requirements/support
 * easier links to cross-reference repository and support links
 * add encryption details for known iaases

I'm interested in feedback if this may be a useful direction or what could be improved, @mfine30 / @voelzmo / opinioners? If useful, I think next step would be to propose individual PRs of these changes and ask CPI leads to review/amend the content before merging and publishing.