### PR TITLE
correct Content-Type header for POST /configs

### DIFF
--- a/content/director-api-v1.md
+++ b/content/director-api-v1.md
@@ -135,7 +135,7 @@ $ curl -s -k https://192.168.50.4:25555/configs?latest=true | jq .
 
 #### Request headers
 
-- **Content-Type** must be `text/json`.
+- **Content-Type** must be `application/json`.
 
 #### Request body
 
@@ -175,7 +175,7 @@ $ curl -s -k -H 'Content-Type: application/json' -d '{"name": "test", "type": "c
 
 #### Request headers
 
-- **Content-Type** must be `text/json`.
+- **Content-Type** must be `application/json`.
 
 #### Request body
 


### PR DESCRIPTION
`text/json` results in a 404.