### PR TITLE
OpenStack IaaS overview page

### DIFF
--- a/content/openstack.md
+++ b/content/openstack.md
@@ -4,35 +4,34 @@ title: OpenStack
 
 # OpenStack
 
-The `openstack` CPI can be used with [OpenStack](https://azure.microsoft.com/).
+The `openstack` CPI can be used with [OpenStack](https://www.openstack.org).
 
  * Release: [cloudfoundry-incubator/bosh-openstack-cpi-release](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release)
  * Issues: [GitHub Issues](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release/issues)
- * Slack: [cloudfoundry#bosh-azure-cpi](https://cloudfoundry.slack.com/messages/bosh-azure-cpi)
+ * Slack: [cloudfoundry#openstack](https://cloudfoundry.slack.com/messages/openstack)
 
 
 ## Requirements
 
 An OpenStack environment running one of the following supported releases:
 
- * [Liberty](http://www.openstack.org/software/liberty) (actively tested)
- * [Mitaka](http://www.openstack.org/software/mitaka) (actively tested)
- * [Newton](http://www.openstack.org/software/newton) (actively tested)
-
-    !!! tip
-        Juno has a [bug](https://bugs.launchpad.net/nova/+bug/1396854) that prevents BOSH to assign specific IPs to VMs. You have to apply a Nova patch to avoid this problem.
+  * [Mitaka](http://www.openstack.org/software/mitaka) (actively tested)
+  * [Newton](http://www.openstack.org/software/newton) (actively tested)
+  * [Ocata](http://www.openstack.org/software/ocata) (actively tested)
+  * [Pike](http://www.openstack.org/software/pike) (actively tested)
 
 And the following OpenStack services:
 
  * [Identity](https://www.openstack.org/software/releases/ocata/components/keystone):
    BOSH authenticates credentials and retrieves the endpoint URLs for other OpenStack services.
  * [Compute](https://www.openstack.org/software/releases/ocata/components/nova):
-   BOSH boots new VMs, assigns floating IPs to VMs, and creates and attaches volumes to VMs.
+   BOSH boots new VMs, assigns floating IPs to VMs
  * [Image](https://www.openstack.org/software/releases/ocata/components/glance):
    BOSH stores stemcells using the Image service.
  * *(Optional)* [OpenStack Networking](https://www.openstack.org/software/releases/ocata/components/neutron):
-   Provides network scaling and automated management functions that are useful when deploying complex distributed systems. **Note:** OpenStack networking is used as default as of v28 of the OpenStack CPI. To disable the use of the OpenStack Networking project, see [using nova-networking](openstack-nova-networking.md).
-
+   Provides network scaling and automated management functions that are useful when deploying complex distributed systems. **Note:** OpenStack networking is used as default as of v28 of the OpenStack CPI.
+ * *(Optional)* [OpenStack Block Storage](https://www.openstack.org/software/releases/ocata/components/cinder):
+   BOSH creates persistent volumes. While it is technically possible to use BOSH on OpenStack without block storage, you won't get persistent volumes without it.
 
 ## Concepts
 
@@ -40,14 +39,15 @@ The following table maps BOSH concepts to their OpenStack-native equivalents.
 
 | BOSH | OpenStack |
 | ---- | --------- |
-| Availability Zone | TODO |
-| Virtual Machine | TODO |
-| VM Config Metadata | BOSH Registry or Config Drive |
-| Network Subnet | TODO |
-| Virtual IP | TODO |
-| Persistent Disk | TODO |
-| Disk Snapshot | TODO |
-| Stemcell | TODO |
+| Availability Zone | [Availability Zone](https://www.mirantis.com/blog/the-first-and-final-word-on-openstack-availability-zones/) |
+| Virtual Machine | [Instance](https://docs.openstack.org/nova/queens/user/launch-instances.html) |
+| Instance Type | [Flavor](https://docs.openstack.org/nova/latest/user/flavors.html) |
+| VM Config Metadata | BOSH Registry, [HTTP Metadata service](https://docs.openstack.org/nova/latest/user/metadata-service.html) or [Config Drive](https://docs.openstack.org/nova/queens/user/config-drive.html) |
+| Network Subnet | [Subnet](https://docs.openstack.org/neutron/queens/admin/intro-os-networking.html) |
+| Virtual IP | [Floating IP](https://docs.openstack.org/nova/queens/user/manage-ip-addresses.html) |
+| Persistent Disk | [Volume](https://docs.openstack.org/cinder/latest/cli/cli-manage-volumes.html) |
+| Disk Snapshot | [Volume Snapshot](https://docs.openstack.org/cinder/latest/cli/cli-manage-volumes.html) |
+| Stemcell | [Virtual Machine Image](https://docs.openstack.org/glance/queens/user/index.html) |
 
 
 ## Feature Support

--- a/content/openstack.md
+++ b/content/openstack.md
@@ -22,15 +22,15 @@ An OpenStack environment running one of the following supported releases:
 
 And the following OpenStack services:
 
- * [Identity](https://www.openstack.org/software/releases/ocata/components/keystone):
+ * [Identity](https://www.openstack.org/software/releases/latest/components/keystone):
    BOSH authenticates credentials and retrieves the endpoint URLs for other OpenStack services.
- * [Compute](https://www.openstack.org/software/releases/ocata/components/nova):
+ * [Compute](https://www.openstack.org/software/releases/latest/components/nova):
    BOSH boots new VMs, assigns floating IPs to VMs
- * [Image](https://www.openstack.org/software/releases/ocata/components/glance):
+ * [Image](https://www.openstack.org/software/releases/latest/components/glance):
    BOSH stores stemcells using the Image service.
- * *(Optional)* [OpenStack Networking](https://www.openstack.org/software/releases/ocata/components/neutron):
+ * *(Optional)* [OpenStack Networking](https://www.openstack.org/software/releases/latest/components/neutron):
    Provides network scaling and automated management functions that are useful when deploying complex distributed systems. **Note:** OpenStack networking is used as default as of v28 of the OpenStack CPI.
- * *(Optional)* [OpenStack Block Storage](https://www.openstack.org/software/releases/ocata/components/cinder):
+ * *(Optional)* [OpenStack Block Storage](https://www.openstack.org/software/releases/latest/components/cinder):
    BOSH creates persistent volumes. While it is technically possible to use BOSH on OpenStack without block storage, you won't get persistent volumes without it.
 
 ## Concepts
@@ -40,14 +40,14 @@ The following table maps BOSH concepts to their OpenStack-native equivalents.
 | BOSH | OpenStack |
 | ---- | --------- |
 | Availability Zone | [Availability Zone](https://www.mirantis.com/blog/the-first-and-final-word-on-openstack-availability-zones/) |
-| Virtual Machine | [Instance](https://docs.openstack.org/nova/queens/user/launch-instances.html) |
+| Virtual Machine | [Instance](https://docs.openstack.org/nova/latest/user/launch-instances.html) |
 | Instance Type | [Flavor](https://docs.openstack.org/nova/latest/user/flavors.html) |
-| VM Config Metadata | BOSH Registry, [HTTP Metadata service](https://docs.openstack.org/nova/latest/user/metadata-service.html) or [Config Drive](https://docs.openstack.org/nova/queens/user/config-drive.html) |
-| Network Subnet | [Subnet](https://docs.openstack.org/neutron/queens/admin/intro-os-networking.html) |
-| Virtual IP | [Floating IP](https://docs.openstack.org/nova/queens/user/manage-ip-addresses.html) |
+| VM Config Metadata | BOSH Registry, [HTTP Metadata service](https://docs.openstack.org/nova/latest/user/metadata-service.html) or [Config Drive](https://docs.openstack.org/nova/latest/user/config-drive.html) |
+| Network Subnet | [Subnet](https://docs.openstack.org/neutron/latest/admin/intro-os-networking.html) |
+| Virtual IP | [Floating IP](https://docs.openstack.org/nova/latest/user/manage-ip-addresses.html) |
 | Persistent Disk | [Volume](https://docs.openstack.org/cinder/latest/cli/cli-manage-volumes.html) |
 | Disk Snapshot | [Volume Snapshot](https://docs.openstack.org/cinder/latest/cli/cli-manage-volumes.html) |
-| Stemcell | [Virtual Machine Image](https://docs.openstack.org/glance/queens/user/index.html) |
+| Stemcell | [Virtual Machine Image](https://docs.openstack.org/glance/latest/user/index.html) |
 
 
 ## Feature Support

--- a/content/openstack.md
+++ b/content/openstack.md
@@ -1,0 +1,75 @@
+---
+title: OpenStack
+---
+
+# OpenStack
+
+The `openstack` CPI can be used with [OpenStack](https://azure.microsoft.com/).
+
+ * Release: [cloudfoundry-incubator/bosh-openstack-cpi-release](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release)
+ * Issues: [GitHub Issues](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release/issues)
+ * Slack: [cloudfoundry#bosh-azure-cpi](https://cloudfoundry.slack.com/messages/bosh-azure-cpi)
+
+
+## Requirements
+
+An OpenStack environment running one of the following supported releases:
+
+ * [Liberty](http://www.openstack.org/software/liberty) (actively tested)
+ * [Mitaka](http://www.openstack.org/software/mitaka) (actively tested)
+ * [Newton](http://www.openstack.org/software/newton) (actively tested)
+
+    !!! tip
+        Juno has a [bug](https://bugs.launchpad.net/nova/+bug/1396854) that prevents BOSH to assign specific IPs to VMs. You have to apply a Nova patch to avoid this problem.
+
+And the following OpenStack services:
+
+ * [Identity](https://www.openstack.org/software/releases/ocata/components/keystone):
+   BOSH authenticates credentials and retrieves the endpoint URLs for other OpenStack services.
+ * [Compute](https://www.openstack.org/software/releases/ocata/components/nova):
+   BOSH boots new VMs, assigns floating IPs to VMs, and creates and attaches volumes to VMs.
+ * [Image](https://www.openstack.org/software/releases/ocata/components/glance):
+   BOSH stores stemcells using the Image service.
+ * *(Optional)* [OpenStack Networking](https://www.openstack.org/software/releases/ocata/components/neutron):
+   Provides network scaling and automated management functions that are useful when deploying complex distributed systems. **Note:** OpenStack networking is used as default as of v28 of the OpenStack CPI. To disable the use of the OpenStack Networking project, see [using nova-networking](openstack-nova-networking.md).
+
+
+## Concepts
+
+The following table maps BOSH concepts to their OpenStack-native equivalents.
+
+| BOSH | OpenStack |
+| ---- | --------- |
+| Availability Zone | TODO |
+| Virtual Machine | TODO |
+| VM Config Metadata | BOSH Registry or Config Drive |
+| Network Subnet | TODO |
+| Virtual IP | TODO |
+| Persistent Disk | TODO |
+| Disk Snapshot | TODO |
+| Stemcell | TODO |
+
+
+## Feature Support
+
+The following sections describe some specific BOSH features supported by the CPI.
+
+
+### Network
+
+The CPI supports multiple NICs being attached to a single VM.
+
+
+| Network Type | Support |
+| ------------ | ------- |
+| Manual | Multiple networks per instance |
+| Dynamic | Single network per instance |
+| VIP | Single network per instance |
+
+
+### Miscellaneous
+
+| Feature | Support |
+| ------- | ------- |
+| Multi-CPI | Supported, [v31](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release/releases/tag/v31)+ |
+| Native Disk Resize | Supported, [v33](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release/releases/tag/v33)+ |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -222,6 +222,7 @@ pages:
     - Common Errors: azure-cpi-errors.md
     - Creating Resources: azure-resources.md
   - OpenStack:
+    - Overview: openstack.md
     - Usage: openstack-cpi.md
     - Common Errors: openstack-cpi-errors.md
     - Using Auto-anti-affinity: openstack-auto-anti-affinity.md


### PR DESCRIPTION
I started adding IaaS overview pages for documenting some of the BOSH+IaaS-specific basics (and to summarize some of the functionalities that (at least I) often end up checking from code).

I already committed [AWS](https://bosh.io/docs/aws/), [Google](https://bosh.io/docs/google/), and [Azure](https://bosh.io/docs/azure/) if you want to see more examples. But I was hoping you or your team might be able to help review and fill in this OpenStack page sometime when you're bored. Feel free to push to the branch and/or merge when you're happy.

Happy to hear feedback on this or the other overviews as well.

Thanks!