### PR TITLE
Add vSphere IaaS overview

### DIFF
--- a/content/vsphere.md
+++ b/content/vsphere.md
@@ -1,0 +1,62 @@
+---
+title: VMware vSphere
+---
+
+# vSphere
+
+The `vsphere` CPI can be used with [VMware vSphere](https://www.vmware.com/products/vsphere.html).
+
+ * Release: [cloudfoundry-incubator/bosh-vsphere-cpi-release](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release)
+ * Issues: [GitHub Issues](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/issues)
+ * Slack: [cloudfoundry#bosh](https://cloudfoundry.slack.com/messages/bosh)
+
+
+## Concepts
+
+The following table maps BOSH concepts to their vSphere-native equivalents.
+
+| BOSH | vSphere |
+| ---- | ------- |
+| Availability Zone | TODO |
+| Virtual Machine | TODO |
+| VM Config Metadata | Virtual Device ISO |
+| Network Subnet | TODO |
+| Virtual IP | TODO |
+| Persistent Disk | TODO |
+| Disk Snapshot | TODO |
+| Stemcell | TODO |
+
+
+## Feature Support
+
+The following sections describe some specific BOSH features supported by the CPI.
+
+
+### Network
+
+The CPI supports multiple NICs being attached to a single VM.
+
+| Network Type | Support |
+| ------------ | ------- |
+| Manual | Multiple networks per instance |
+| Dynamic | Not Supported |
+| VIP | Not Supported |
+
+
+### Encryption
+
+vSphere supports disk encryption and customer-managed keys when managed through policy configuration within the vCenter 6.5+ ([learn more](https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.security.doc/GUID-047A06F6-DE3D-4428-998C-DAAE84A33316.html)). For this functionality, encryption occurs at the hypervisor level which is transparent to the VM. Once enabled within vCenter, no additional configuration is required for the CPI.
+
+| Disk Type | Encryption |
+| --------- | ---------- |
+| Root Disk | Supported |
+| Ephemeral Disk | Supported |
+| Persistent Disk | Supported |
+
+
+### Miscellaneous
+
+| Feature | Support |
+| ------- | ------- |
+| Multi-CPI | Supported, [v34](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/releases/tag/v34)+ |
+| Native Disk Resize | Not Supported |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -241,6 +241,7 @@ pages:
   - VMware vCloud:
     - Usage: vcloud-cpi.md
   - VMware vSphere:
+    - Overview: vsphere.md
     - Usage: vsphere-cpi.md
     - Common Errors: vsphere-cpi-errors.md
     - Recovery from an ESXi Host Failure: vsphere-esxi-host-failure.md


### PR DESCRIPTION
We've been adding overview pages to describe some of the bigger picture, IaaS-specific feature and support information. This adds a vSphere-specific one, similar to the the [AWS](https://bosh.io/docs/aws/) and [OpenStack](https://bosh.io/docs/openstack/) ones we have recently added.