### PR TITLE
Provide documentation for post-stop script

### DIFF
--- a/content/post-stop.md
+++ b/content/post-stop.md
@@ -1,0 +1,30 @@
+(See [Job Lifecycle](job-lifecycle.md) for an explanation of when post-stop scripts run.)
+
+!!! note
+    This feature is available with bosh-release v265+ and only for releases deployed with 3125+ stemcells.
+
+Release job can have a post-stop script that will run when the job is restarted or stopped. This script will run following a monit stop for all jobs on the VM in parallel.
+
+---
+## Job Configuration {: #job-configuration }
+
+To add a post-deploy script to a release job:
+
+1. Create a script with any name in the templates directory of a release job.
+1. In the `templates` section of the release job spec file, add the script name and the `bin/post-stop` directory as a key value pair.
+
+Example:
+
+```yaml
+---
+name: cassandra_node
+templates:
+  post-stop.erb: bin/post-stop
+```
+
+---
+## Script Implementation {: #script-implementation }
+
+Post-stop script is usually just a regular shell script. Since post-start script is executed in a similar way as other release job scripts (start, stop, drain scripts) you can use job's package dependencies.
+
+Post-stop script should be idempotent. It may be called multiple times after a process is stopped.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -185,6 +185,7 @@ pages:
         - Pre-start: pre-start.md
         - Post-start: post-start.md
         - Post-deploy: post-deploy.md
+        - Post-stop: post-stop.md
     - Links:
       - Common Types: links-common-types.md
   - Operating Systems:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ pages:
         - Configuring Director: director-users-uaa.md
         - Using Teams: director-users-uaa-perms.md
       - Configuring SSL Certificates: director-certs.md
+      - Director SSL Certificate Configuration with OpenSSL: director-certs-openssl.md
     - Configuring the Database:
       - Builtin PostgreSQL: director-configure-db.md
       - External MySQL: director-configure-db.md
@@ -196,6 +197,7 @@ pages:
     # docs we should keep linkable
     - Basic Workflow: basic-workflow.md
     - Deployment Manifest v1: deployment-manifest.md
+    - Sample Manifest: sample-manifest.md
     - CLI v1 Installation: bosh-cli.md
     - CLI v1 Commands: sysadmin-commands.md
     - CLI v1 Backup / Restore: director-backup.md


### PR DESCRIPTION
As outlined in #528, [Update Lifecycle](https://bosh.io/docs/job-lifecycle/) links to documentation for `post-stop` scripts but this page was non-existent. The current change outlines what `post-stop` scripts are alongside an example of how they can be used.

This PR also fixes some links to existing documentation that could not be viewed as they were not reflected in `mkdocs.yml`.