### PR TITLE
add ubuntu-18.04 or higher install 

### DIFF
--- a/content/cli-v2-install.md
+++ b/content/cli-v2-install.md
@@ -69,6 +69,11 @@ If you are running on Ubuntu, ensure the following packages are installed on you
 ```shell
 $ sudo apt-get install -y build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3
 ```
+ 
+You are running on ubuntu18.04 or higher, ensure the following packages are installed on your system:
+```shell
+$ sudo apt-get install -y build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6-dev libyaml-dev libsqlite3-dev sqlite3
+```
 
 
 ### macOS


### PR DESCRIPTION
in ubuntu-18.04, `libreadline6 libreadline-dev` been deleted. Should be replaced with `libreadline-dev `