### PR TITLE
Add warnings for CLI repack-stemcell

### DIFF
--- a/content/cli-v2.md
+++ b/content/cli-v2.md
@@ -164,6 +164,9 @@ See [Uploading Stemcells](uploading-stemcells.md).
 
 - `bosh repack-stemcell src.tgz dst.tgz [--name=name] [--version=ver] [--cloud-properties=json-string]`
 
+    !!! warning
+        Starting in version CLI v5.4.0, repacking a stemcell will preserve a new field `api_version` in the manifest. Repacking any stemcells with `api_version` in their manifest with CLI v5.3.1 and lower will omit the field.
+
     Produces new stemcell tarball with updated properties such as name, version, and cloud properties.
 
     See [Repacking stemcells](repack-stemcell.md) for details.

--- a/content/repack-stemcell.md
+++ b/content/repack-stemcell.md
@@ -1,5 +1,8 @@
 !!! note
-    Applies to CLI v2 v2.0.12+.
+    Applies to CLI v2.0.12+.
+
+!!! warning
+    Starting in version CLI v5.4.0, repacking a stemcell will preserve a new field `api_version` in the manifest. Repacking any stemcells with `api_version` in their manifest with CLI v5.3.1 and lower will omit the field.
 
 The [CLI v2](cli-v2.md) includes a command to repack stemcells; this enables limited customization of a stemcell including the following:
 


### PR DESCRIPTION
- prior to 5.4.0 api_version will be stripped

[#160941635](https://www.pivotaltracker.com/story/show/160941635)