### PR TITLE
Fix cpi urls

### DIFF
--- a/content/aws-cpi.md
+++ b/content/aws-cpi.md
@@ -161,7 +161,7 @@ Schema:
 
 * **kms\_key\_arn** [String, optional]: Encrypts the disks using an encryption key stored in the [AWS Key Management Service (KMS)](https://aws.amazon.com/kms/). The format of the ID is `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`. Be sure to use the Key ID, not the Alias. If this property is omitted and `encrypted` is `true`, the disks will be encrypted using your account's default `aws/ebs` encryption key. Available in v67+.
 
-See [all configuration options](https://bosh.io/jobs/cpi?source=github.com/cloudfoundry-incubator/bosh-aws-cpi-release).
+See [all configuration options](https://bosh.io/jobs/cpi?source=github.com/cloudfoundry/bosh-aws-cpi-release).
 
 Example with hard-coded credentials:
 

--- a/content/aws-iam-users.md
+++ b/content/aws-iam-users.md
@@ -36,4 +36,4 @@
 
     ![image](images/deploy-microbosh-to-aws/add-iam-inline-policy.png)
 
-    The CPI provides a [sample policy](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/blob/master/docs/iam-policy.json) which supports all functionality provided by the CPI. Please review the policy to further limit unnecessary access for your environment.
+    The CPI provides a [sample policy](https://github.com/cloudfoundry/bosh-aws-cpi-release/blob/master/docs/iam-policy.json) which supports all functionality provided by the CPI. Please review the policy to further limit unnecessary access for your environment.

--- a/content/aws.md
+++ b/content/aws.md
@@ -6,8 +6,8 @@ title: Amazon Web Services
 
 The `aws` CPI can be used with [Amazon Web Services](https://aws.amazon.com/).
 
- * Release: [cloudfoundry-incubator/bosh-aws-cpi-release](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release)
- * Issues: [GitHub Issues](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/issues)
+ * Release: [cloudfoundry/bosh-aws-cpi-release](https://github.com/cloudfoundry/bosh-aws-cpi-release)
+ * Issues: [GitHub Issues](https://github.com/cloudfoundry/bosh-aws-cpi-release/issues)
  * Slack: [cloudfoundry#bosh](https://cloudfoundry.slack.com/messages/bosh)
 
 
@@ -49,9 +49,9 @@ AWS supports encryption functionality through their [Key Management Service](htt
 
 | Platform | Disk Type | Encryption | Customer-managed Keys |
 | -------- | --------- | ---------- | --------------------- |
-| Linux | Root Disk | Supported, [v69](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/releases/tag/v69)+ | Supported |
-| Linux | Ephemeral Disk | Supported, [v69](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/releases/tag/v69)+ | Supported |
-| Linux | Persistent Disk | Supported, [v69](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/releases/tag/v69)+ | Supported |
+| Linux | Root Disk | Supported, [v69](https://github.com/cloudfoundry/bosh-aws-cpi-release/releases/tag/v69)+ | Supported |
+| Linux | Ephemeral Disk | Supported, [v69](https://github.com/cloudfoundry/bosh-aws-cpi-release/releases/tag/v69)+ | Supported |
+| Linux | Persistent Disk | Supported, [v69](https://github.com/cloudfoundry/bosh-aws-cpi-release/releases/tag/v69)+ | Supported |
 | Windows | Root Disk | Partially Supported (manual steps required) | Supported |
 | Windows | Ephemeral Disk | Not Supported | n/a |
 | Windows | Persistent Disk | Not Supported | n/a |
@@ -63,5 +63,5 @@ AWS supports encryption functionality through their [Key Management Service](htt
 
 | Feature   | Support |
 | --------- | ------- |
-| Multi-CPI | Supported, [v61](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/releases/tag/v61)+ |
+| Multi-CPI | Supported, [v61](https://github.com/cloudfoundry/bosh-aws-cpi-release/releases/tag/v61)+ |
 | Native Disk Resize | Not Supported |

--- a/content/azure-cpi-errors.md
+++ b/content/azure-cpi-errors.md
@@ -76,11 +76,11 @@ The workaround is:
 
 For CPI v11 or later, the compatible stemcell version is v3181 or later. If the stemcell version is older than v3181, you may hit the following failure when deploying BOSH.
 
-It is recommended to use the latest version. For example, Stemcell v3232.5 or later, and CPI v12 or later. You may hit the issue [#135](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/issues/135) if you still use an older stemcell than v3232.5.
+It is recommended to use the latest version. For example, Stemcell v3232.5 or later, and CPI v12 or later. You may hit the issue [#135](https://github.com/cloudfoundry/bosh-azure-cpi-release/issues/135) if you still use an older stemcell than v3232.5.
 
 
 ## Out of memory
 
 If you hit `Out of memory` or `Virtual memory exhausted`, please check whether you use Standard_A0 as instance_type. You should change instance_type to a VM size with more memory.
 
-Please reference the [issue #230](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/issues/230).
+Please reference the [issue #230](https://github.com/cloudfoundry/bosh-azure-cpi-release/issues/230).

--- a/content/azure-cpi.md
+++ b/content/azure-cpi.md
@@ -2,7 +2,7 @@ This topic describes cloud properties for different resources created by the Azu
 
 ## AZs {: #azs }
 
-* **availability_zone** [String, optional]: Availability zone to use for creating instances (available in v33+). Possible values: `'1'`, `'2'`, `'3'`. Read this [document](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) to get regions and VM sizes on Azure that support availability zones. [More details about availability zone](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/tree/master/docs/advanced/availability-zone).
+* **availability_zone** [String, optional]: Availability zone to use for creating instances (available in v33+). Possible values: `'1'`, `'2'`, `'3'`. Read this [document](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) to get regions and VM sizes on Azure that support availability zones. [More details about availability zone](https://github.com/cloudfoundry/bosh-azure-cpi-release/tree/master/docs/advanced/availability-zone).
 
 Example:
 
@@ -92,7 +92,7 @@ Schema for `cloud_properties` section:
     * If `availability_zone` is specified for the VM, [standard sku load balancer](https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-standard-overview) must be used, as `basic sku load balancer` does not work for zone.
 * **application_gateway** [String, optional]: Name of the [application gateway](https://azure.microsoft.com/en-us/services/application-gateway/) which the VMs should be associated to.
     * This property is supported in CPI v28+.
-    * You need to create the application gateway manually before configuring it. Please refer to [the guidance](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/tree/master/docs/advanced/application-gateway).
+    * You need to create the application gateway manually before configuring it. Please refer to [the guidance](https://github.com/cloudfoundry/bosh-azure-cpi-release/tree/master/docs/advanced/application-gateway).
 * **security_group** [String, optional]: The [security group](https://azure.microsoft.com/en-us/documentation/articles/virtual-networks-nsg/) to apply to network interfaces of all VMs who have this VM type/extension. The security group of a network interface can be specified either in a VM type/extension (higher priority) or a network configuration (lower priority). If it's not specified in neither places, the default security group (specified by `default_security_group` in the global CPI settings) will be used.
 * **application\_security\_groups** [Array, optional]: The [application security group](https://docs.microsoft.com/en-us/azure/virtual-network/security-overview#application-security-groups) to apply to network interfaces of all VMs who have this VM type/extension. The application security groups of a network interface can be specified either in a VM type/extension (higher priority) or a network configuration (lower priority).
     * This property is supported in v31+.
@@ -100,10 +100,10 @@ Schema for `cloud_properties` section:
 * **ip_forwarding** [Boolean, optional]: The flag to enable [ip forwarding](https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-network-interface#enable-or-disable-ip-forwarding) for network interfaces of all VMs who have this VM type/extension. The ip forwarding can be enabled/disabled either in a VM type/extension (higher priority) or a network configuration (lower priority). If it's not specified in neither places, the default value is `false`. Available in v35.3.0+.
 * **accelerated_networking** [Boolean, optional]: The flag to enable [accelerated networking](https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli) for network interfaces of all VMs who have this VM type/extension. The accelerated networking can be enabled/disabled either in a VM type/extension (higher priority) or a network configuration (lower priority). If it's not specified in neither places, the default value is `false`. Available in v35.4.0+. This feature needs ubuntu-xenial v81+ and [specific instance type](https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli#supported-vm-instances).
 
-* **assign\_dynamic\_public\_ip** [Boolean, optional]: Enable to create and assign dynamic public IP to the VM automatically (to solve the [azure SNAT issue](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/issues/217)). Default value is `false`. Only the VM without vip will be assigned a dynamic public IP when this value is set to true, and the dynamic public IP will be deleted when the VM is deleted.
+* **assign\_dynamic\_public\_ip** [Boolean, optional]: Enable to create and assign dynamic public IP to the VM automatically (to solve the [azure SNAT issue](https://github.com/cloudfoundry/bosh-azure-cpi-release/issues/217)). Default value is `false`. Only the VM without vip will be assigned a dynamic public IP when this value is set to true, and the dynamic public IP will be deleted when the VM is deleted.
 
-* **availability_zone** [String, optional]: Availability zone to use for creating instances (available in v33+). Possible values: `'1'`, `'2'`, `'3'`. Read this [document](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) to get regions and VM sizes on Azure that support availability zones. [More details about availability zone](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/tree/master/docs/advanced/availability-zone).
-* **availability_set** [String, optional]: Name of an [availability set](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-manage-availability/) to use for VMs. [More details](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/tree/master/docs/advanced/deploy-cloudfoundry-for-enterprise#availability-set).
+* **availability_zone** [String, optional]: Availability zone to use for creating instances (available in v33+). Possible values: `'1'`, `'2'`, `'3'`. Read this [document](https://docs.microsoft.com/en-us/azure/availability-zones/az-overview) to get regions and VM sizes on Azure that support availability zones. [More details about availability zone](https://github.com/cloudfoundry/bosh-azure-cpi-release/tree/master/docs/advanced/availability-zone).
+* **availability_set** [String, optional]: Name of an [availability set](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-manage-availability/) to use for VMs. [More details](https://github.com/cloudfoundry/bosh-azure-cpi-release/tree/master/docs/advanced/deploy-cloudfoundry-for-enterprise#availability-set).
     * If available set does not exist, it will be automatically created.
     * If `availability_set` is not specified, Azure CPI will search `env.bosh.group` as the name of availability set.
         1. [bosh release](https://bosh.io/releases/github.com/cloudfoundry/bosh?all=1) v258+ will generate a value for `env.bosh.group` automatically.
@@ -117,7 +117,7 @@ Schema for `cloud_properties` section:
     * For Azure, the default value of an unmanaged availability set is `3`. The default value of a managed availability set is `2`, because [some regions don't support 3 fault domains for now](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-windows-manage-availability#configure-multiple-virtual-machines-in-an-availability-set-for-redundancy)
     * For Azure Stack, the default value is `1`. Before 1802 update, only `1` is allowed. After [1802 update](https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-update-1802), you can configure up to 3 fault domains.
 
-* **storage\_account\_name** [String, optional]: Storage account for VMs. Valid only when `use_managed_disks` is `false`. If this is not set, the VMs will be created in the default storage account. See [this document](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/tree/master/docs/advanced/deploy-cloudfoundry-for-enterprise#multiple-storage-accounts) for more details on why this option exists.
+* **storage\_account\_name** [String, optional]: Storage account for VMs. Valid only when `use_managed_disks` is `false`. If this is not set, the VMs will be created in the default storage account. See [this document](https://github.com/cloudfoundry/bosh-azure-cpi-release/tree/master/docs/advanced/deploy-cloudfoundry-for-enterprise#multiple-storage-accounts) for more details on why this option exists.
     * If you use `DS-series` or `GS-series` as `instance_type`, you should set this to a premium storage account. See more information about [Azure premium storage](https://azure.microsoft.com/en-us/documentation/articles/storage-premium-storage-preview-portal/). See [avaliable regions](http://azure.microsoft.com/en-us/regions/#services) where you can create premium storage accounts.
     * If you use a different storage account which must be in the same resource group, please make sure:
         1. The permissions for the container `stemcell` in the default storage account is set to `Public read access for blobs only`.
@@ -233,13 +233,13 @@ Schema:
 * **tenant_id** [String, required]: Tenant ID of the service principal.
 * **client_id** [String, required]: Client ID of the service principal.
 * **client_secret** [String, optional]: Client secret of the service principal.
-* **certificate** [String, optional]: The certificate for your service principal. Azure CPI v35.0.0+ supports the [service principal with a certificate](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/tree/master/docs/advanced/use-service-principal-with-certificate). Only one of `client_secret` and `certificate` can be specified.
+* **certificate** [String, optional]: The certificate for your service principal. Azure CPI v35.0.0+ supports the [service principal with a certificate](https://github.com/cloudfoundry/bosh-azure-cpi-release/tree/master/docs/advanced/use-service-principal-with-certificate). Only one of `client_secret` and `certificate` can be specified.
 * **resource\_group\_name** [String, required]: Resource group name.
 * **storage\_account\_name** [String, optional]: Storage account name. It will be used as a default storage account for VM disks and stemcells. If `use_managed_disks` is `false`, `storage_account_name` is required. Otherwise, `storage_account_name` is optional.
 * **ssh_user** [String, required]: SSH username. Default: `vcap`.
 * **ssh\_public\_key** [String, required]: SSH public key.
 * **default\_security\_group** [String, optional]: Name of the default [security group](https://azure.microsoft.com/en-us/documentation/articles/virtual-networks-nsg/) that will be applied to all created VMs. This property is required before v35.0.0, and optional in v35.0.0+.
-* **azure_stack** [Hash, optional]: [Configration for AzureStack](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/tree/master/docs/advanced/azure-stack). Available in v23+.
+* **azure_stack** [Hash, optional]: [Configration for AzureStack](https://github.com/cloudfoundry/bosh-azure-cpi-release/tree/master/docs/advanced/azure-stack). Available in v23+.
     * **domain** [String, optional]: The domain for your AzureStack deployment. Default is `local.azurestack.external`. You can use the default value for [Azure Stack development kit](https://azure.microsoft.com/en-us/overview/azure-stack/development-kit/). To get this value for Azure Stack integrated systems, contact your service provider.
     * **authentication** [String, optional]: The authentication type for your AzureStack deployment. Possible values are: `AzureAD`, `AzureChinaCloudAD` and `ADFS`. You need to specify `certificate` if you select `ADFS`, because Azure Stack with ADFS authentication only supports the service principal with a certificate.
     * **resource** [String, optional]: Active Directory Service Endpoint Resource ID, where you can get the token for your AzureStack deployment.
@@ -259,7 +259,7 @@ Schema:
 * **enable_telemetry** [Boolean, optional]: A flag to enable telemetry on CPI calls on Azure. Available since v35.2.0. The default value is `true` in v35.2.0, and is `false` in v35.3.0+.
 * **enable\_vm\_boot\_diagnostics** [Boolean, optional]: A flag to enable VM boot diagnostics on Azure. Available since v35.2.0. The default value is `true` in v35.2.0, and is `false` in v35.3.0+.
 
-See [all configuration options](https://bosh.io/jobs/cpi?source=github.com/cloudfoundry-incubator/bosh-azure-cpi-release).
+See [all configuration options](https://bosh.io/jobs/cpi?source=github.com/cloudfoundry/bosh-azure-cpi-release).
 
 See [Creating Azure resources](azure-resources.md) page for more details on how to create and configure above resources.
 

--- a/content/azure.md
+++ b/content/azure.md
@@ -6,8 +6,8 @@ title: Microsoft Azure
 
 The `azure` CPI can be used with [Microsoft Azure](https://azure.microsoft.com/).
 
- * Release: [cloudfoundry-incubator/bosh-azure-cpi-release](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release)
- * Issues: [GitHub Issues](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/issues)
+ * Release: [cloudfoundry/bosh-azure-cpi-release](https://github.com/cloudfoundry/bosh-azure-cpi-release)
+ * Issues: [GitHub Issues](https://github.com/cloudfoundry/bosh-azure-cpi-release/issues)
  * Slack: [cloudfoundry#bosh-azure-cpi](https://cloudfoundry.slack.com/messages/bosh-azure-cpi)
 
 

--- a/content/build-cpi.md
+++ b/content/build-cpi.md
@@ -2,7 +2,7 @@ This topic describes how to build a CPI.
 
 ## Distribution {: #distribution }
 
-CPIs are distributed as regular releases, typically with a release job called `cpi` and a few packages that provide compilation/runtime environment for that job if necessary (e.g. [bosh-aws-cpi-release](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release) includes Ruby and [bosh-warden-cpi-release](https://github.com/cppforlife/bosh-warden-cpi-release) includes golang). To qualify to be a CPI release, it must include a release job that has `bin/cpi` executable.
+CPIs are distributed as regular releases, typically with a release job called `cpi` and a few packages that provide compilation/runtime environment for that job if necessary (e.g. [bosh-aws-cpi-release](https://github.com/cloudfoundry/bosh-aws-cpi-release) includes Ruby and [bosh-warden-cpi-release](https://github.com/cppforlife/bosh-warden-cpi-release) includes golang). To qualify to be a CPI release, it must include a release job that has `bin/cpi` executable.
 
 Both `bosh create-env` command and the Director expect to be configured with a CPI release to function properly. In the case of `bosh create-env` command, specified CPI release is unpacked and installed on the machine running the command. For the Director, CPI release job is colocated on the same VM, so that the director release job can access it.
 
@@ -18,10 +18,10 @@ If you are getting started with a new CPI, you may be interested in using one of
 
 The [`bosh_cpi`](https://rubygems.org/gems/bosh_cpi) gem provides a `Bosh::Cpi::Cli` class which handles the deserialization and serialization of the RPC calls. You can see examples of this in the following CPIs:
 
- * [Amazon Web Services CPI Release](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release)
- * [Microsoft Azure CPI Release](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release)
- * [OpenStack CPI Release](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release)
- * [VMware vSphere CPI Release](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release)
+ * [Amazon Web Services CPI Release](https://github.com/cloudfoundry/bosh-aws-cpi-release)
+ * [Microsoft Azure CPI Release](https://github.com/cloudfoundry/bosh-azure-cpi-release)
+ * [OpenStack CPI Release](https://github.com/cloudfoundry/bosh-openstack-cpi-release)
+ * [VMware vSphere CPI Release](https://github.com/cloudfoundry/bosh-vsphere-cpi-release)
  * [VMware vCloud CPI Release](https://github.com/cloudfoundry-incubator/bosh-vcloud-cpi-release)
 
 
@@ -29,7 +29,7 @@ The [`bosh_cpi`](https://rubygems.org/gems/bosh_cpi) gem provides a `Bosh::Cpi::
 
 There are a few CPI releases written in Go, as well:
 
- * [Google CPI Release](https://github.com/cloudfoundry-incubator/bosh-google-cpi-release)
+ * [Google CPI Release](https://github.com/cloudfoundry/bosh-google-cpi-release)
  * [VirtualBox CPI Release](https://github.com/cppforlife/bosh-virtualbox-cpi-release)
  * [Warden CPI Release](https://github.com/cppforlife/bosh-warden-cpi-release)
 

--- a/content/cpi-api-v1-method/create-network.md
+++ b/content/cpi-api-v1-method/create-network.md
@@ -77,7 +77,7 @@ Properties required for creating the network. It may contain `range` and `gatewa
 
 ### Implementations
 
- * [cloudfoundry-incubator/bosh-vsphere-cpi-release](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/blob/master/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb#L720-L725)
+ * [cloudfoundry/bosh-vsphere-cpi-release](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/blob/master/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb#L720-L725)
 
 
 ## Related

--- a/content/cpi-api-v1-method/delete-network.md
+++ b/content/cpi-api-v1-method/delete-network.md
@@ -30,7 +30,7 @@ No return value.
 
 ### Implementations
 
- * [cloudfoundry-incubator/bosh-vsphere-cpi-release](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/blob/master/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb#L727-L731)
+ * [cloudfoundry-incubator/bosh-vsphere-cpi-release](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/blob/master/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb#L727-L731)
 
 
 ## Related

--- a/content/cpi-api-v1-method/has-disk.md
+++ b/content/cpi-api-v1-method/has-disk.md
@@ -20,7 +20,7 @@ This method is mostly used by the consistency check tool (cloudcheck) to determi
 
 ### Implementations
 
- * [cloudfoundry-incubator/bosh-vsphere-cpi-release](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/blob/dfe878579cbab768af07a12bb5543cd016cbb762/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb#L129)
+ * [cloudfoundry/bosh-vsphere-cpi-release](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/blob/dfe878579cbab768af07a12bb5543cd016cbb762/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb#L129)
 
 
 ## Related

--- a/content/cpi-api-v1-method/resize-disk.md
+++ b/content/cpi-api-v1-method/resize-disk.md
@@ -22,7 +22,7 @@ No return value
 
 ### Implementations
 
- * [cloudfoundry-incubator/bosh-openstack-cpi-release](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release/blob/88e1c6d402b3c4ce23ad39ebdf5ab5fc93790127/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb#L701)
+ * [cloudfoundry/bosh-openstack-cpi-release](https://github.com/cloudfoundry/bosh-openstack-cpi-release/blob/88e1c6d402b3c4ce23ad39ebdf5ab5fc93790127/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb#L701)
 
 
 ## Related

--- a/content/cpi-api-v1-method/set-disk-metadata.md
+++ b/content/cpi-api-v1-method/set-disk-metadata.md
@@ -42,7 +42,7 @@ No return value
 
 ### Implementations
 
- * [cloudfoundry-incubator/bosh-openstack-cpi-release](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release/blob/0c8ee8951cab41d0ddc86591719d55d8a783ac98/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb#L629)
+ * [cloudfoundry/bosh-openstack-cpi-release](https://github.com/cloudfoundry/bosh-openstack-cpi-release/blob/0c8ee8951cab41d0ddc86591719d55d8a783ac98/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb#L629)
 
 
 ## Related

--- a/content/cpi-api-v1-method/set-vm-metadata.md
+++ b/content/cpi-api-v1-method/set-vm-metadata.md
@@ -38,7 +38,7 @@ No return value
 
 ### Implementations
 
- * [cloudfoundry-incubator/bosh-vsphere-cpi-release](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/blob/dfe878579cbab768af07a12bb5543cd016cbb762/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb#L433)
+ * [cloudfoundry/bosh-vsphere-cpi-release](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/blob/dfe878579cbab768af07a12bb5543cd016cbb762/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb#L433)
 
 
 ## Related

--- a/content/google-cpi.md
+++ b/content/google-cpi.md
@@ -163,7 +163,7 @@ disk_types:
 
 The CPI can only talk to a single Google Compute Engine region.
 
-See [all configuration options](https://bosh.io/jobs/google_cpi?source=github.com/cloudfoundry-incubator/bosh-google-cpi-release).
+See [all configuration options](https://bosh.io/jobs/google_cpi?source=github.com/cloudfoundry/bosh-google-cpi-release).
 
 ---
 ## Example Cloud Config {: #cloud-config }

--- a/content/google.md
+++ b/content/google.md
@@ -6,8 +6,8 @@ title: Google Cloud Platform
 
 The `google` CPI can be used with [Google Cloud Platform](https://cloud.google.com/).
 
- * Release: [cloudfoundry-incubator/bosh-google-cpi-release](https://github.com/cloudfoundry-incubator/bosh-google-cpi-release)
- * Issues: [GitHub Issues](https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/issues)
+ * Release: [cloudfoundry/bosh-google-cpi-release](https://github.com/cloudfoundry/bosh-google-cpi-release)
+ * Issues: [GitHub Issues](https://github.com/cloudfoundry/bosh-google-cpi-release/issues)
  * Slack: [cloudfoundry#bosh-gce-cpi](https://cloudfoundry.slack.com/messages/bosh-gce-cpi)
 
 

--- a/content/init-azure.md
+++ b/content/init-azure.md
@@ -4,7 +4,7 @@ This document shows how to initialize new [environment](terminology.md#environme
 
 If you do not have an Azure account, [create one](https://azure.microsoft.com/en-us/pricing/free-trial/).
 
-Then follow this [guide](https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release/blob/master/docs/get-started/create-service-principal.md) to create your Azure service principal.
+Then follow this [guide](https://github.com/cloudfoundry/bosh-azure-cpi-release/blob/master/docs/get-started/create-service-principal.md) to create your Azure service principal.
 
 We strongly recommend you to use Azure template [bosh-setup](https://github.com/Azure/azure-quickstart-templates/tree/master/bosh-setup) to initialize the new environment on Microsoft Azure.
 

--- a/content/init-vsphere.md
+++ b/content/init-vsphere.md
@@ -38,7 +38,7 @@ This document shows how to set up new [environment](terminology.md#environment) 
 
       - Configure `vcenter_ip` (e.g. '192.168.0.10') with the IP of the vCenter.
       - Configure `vcenter_user` (e.g. 'root') and `vcenter_password` (e.g. 'vmware') with vCenter user name and password.
-      BOSH does not require user to be an admin, but it does require the following [privileges](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/blob/master/docs/required_vcenter_privileges.md).
+      BOSH does not require user to be an admin, but it does require the following [privileges](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/blob/master/docs/required_vcenter_privileges.md).
       - Configure `vcenter_dc` (e.g. 'my-dc') with the name of the datacenter the Director will use for VM creation.
       - Configure `vcenter_vms` (e.g. 'my-bosh-vms') and `TEMPLATES-FOLDER-NAME` (e.g. 'my-bosh-templates') with the name of the folder created to hold VMs and the name of the folder created to hold stemcells. Folders will be automatically created under the chosen datacenter.
       - Configure `vcenter_ds` (e.g. 'datastore[1-9]') with a regex matching the names of potential datastores the Director will use for storing VMs and associated persistent disks.

--- a/content/openstack-cpi.md
+++ b/content/openstack-cpi.md
@@ -65,12 +65,12 @@ Schema for `cloud_properties` section:
 * **security_groups** [Array, optional]: Array of security group names or UUIDs to apply for all VMs that are placed on this network. Defaults to security groups specified by `default_security_groups` in the global CPI settings unless security groups are specified on one of the VM networks. If security groups are specified on a resource pool and a network, the resource pool security groups takes precedence since CPI v34+. In older CPI versions prior v34, security groups can either be specified for a network or a resource pool. Security group UUIDs can be used since CPI v39+.
 * **key_name** [String, optional]: Key pair name. Defaults to key pair name specified by `default_key_name` in the global CPI settings. Example: `bosh`.
 * **scheduler_hints** [Hash, optional]: Data passed to the OpenStack Filter scheduler to influence its decision where new VMs can be placed. See [VM Anti-Affinity](vm-anti-affinity.md#openstack) for a detailed example. Example: `{ group: af09abf2-2283... }`
-* **root_disk** [Hash, optional]: Custom root disk properties. Requires `boot_from_volume: true` either [globally](https://bosh.io/jobs/openstack_cpi?source=github.com/cloudfoundry-incubator/bosh-openstack-cpi-release#p=openstack.boot_from_volume) or locally in this VM Type to enable cinder-backed boot volumes. Available in v25+.
+* **root_disk** [Hash, optional]: Custom root disk properties. Requires `boot_from_volume: true` either [globally](https://bosh.io/jobs/openstack_cpi?source=github.com/cloudfoundry/bosh-openstack-cpi-release#p=openstack.boot_from_volume) or locally in this VM Type to enable cinder-backed boot volumes. Available in v25+.
     * **size** [Integer, required]: Specifies the disk size in gigabytes.
 * **loadbalancer_pools** [Array, optional]:  Array of Hashes defining LBaaSv2 pools to attach this instance to. Requires neutron LBaaSv2 extension and OpenStack Mitaka or newer. Available in v32+.
     * **name** [String, required]: The name of the LBaaSv2 loadbalancer pool
     * **port** [Integer, required]: The port exposed on the instance
-* **boot\_from\_volume** [Boolean, optional]: Override global [`boot_from_volume`](https://bosh.io/jobs/openstack_cpi?source=github.com/cloudfoundry-incubator/bosh-openstack-cpi-release#p=openstack.boot_from_volume) to enable cinder-backed boot volumes for this VM Type. Available in v34+.
+* **boot\_from\_volume** [Boolean, optional]: Override global [`boot_from_volume`](https://bosh.io/jobs/openstack_cpi?source=github.com/cloudfoundry/bosh-openstack-cpi-release#p=openstack.boot_from_volume) to enable cinder-backed boot volumes for this VM Type. Available in v34+.
 
 Example of an `m1.small` instance:
 
@@ -142,7 +142,7 @@ disk_pools:
 ---
 ## Global Configuration {: #global }
 
-See [CPI job configuration](https://bosh.io/jobs/openstack_cpi?source=github.com/cloudfoundry-incubator/bosh-openstack-cpi-release) for details.
+See [CPI job configuration](https://bosh.io/jobs/openstack_cpi?source=github.com/cloudfoundry/bosh-openstack-cpi-release) for details.
 
 Schema:
 

--- a/content/openstack-multiple-networks.md
+++ b/content/openstack-multiple-networks.md
@@ -11,11 +11,11 @@ such as default gateway, DNS, and MTU. If you require specific values for these 
 you will need to set them by other means.
 
 1. In your Director deployment manifest, set [`properties.openstack.use_dhcp: false`]
-   (https://bosh.io/jobs/openstack_cpi?source=github.com/cloudfoundry-incubator/bosh-openstack-cpi-release#p=openstack.use_dhcp).
+   (https://bosh.io/jobs/openstack_cpi?source=github.com/cloudfoundry/bosh-openstack-cpi-release#p=openstack.use_dhcp).
    This means the BOSH agent will configure the network devices without DHCP. This is a Director-wide setting
    and switches off DHCP for all VMs deployed with this Director.
 1. In your Director deployment manifest, set [`properties.openstack.config_drive: cdrom`]
-   (https://bosh.io/jobs/openstack_cpi?source=github.com/cloudfoundry-incubator/bosh-openstack-cpi-release#p=openstack.config_drive).
+   (https://bosh.io/jobs/openstack_cpi?source=github.com/cloudfoundry/bosh-openstack-cpi-release#p=openstack.config_drive).
    This means OpenStack will mount a cdrom drive to distribute meta-data and user-data instead of using an HTTP metadata service.
 1. In your [BOSH network configuration](networks.md#manual), set `gateway` and `dns` to allow outbound communication.
 1. If you're not using VLAN, but a tunnel mechanism for Neutron networking, you also need to set the MTU for your network devices on *all* VMs:

--- a/content/personas.md
+++ b/content/personas.md
@@ -115,5 +115,5 @@ A CPI Developer is primarily interested in seeing support for a particular IaaS 
 
 Some examples of CPI Developers are...
 
- * VMware team managing [cloudfoundry-incubator/bosh-vsphere-cpi-release](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release)
- * SAP team managing [cloudfoundry-incubator/bosh-openstack-cpi-release](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release)
+ * VMware team managing [cloudfoundry/bosh-vsphere-cpi-release](https://github.com/cloudfoundry/bosh-vsphere-cpi-release)
+ * SAP team managing [cloudfoundry/bosh-openstack-cpi-release](https://github.com/cloudfoundry/bosh-openstack-cpi-release)

--- a/content/v2-migration-guide.md
+++ b/content/v2-migration-guide.md
@@ -116,7 +116,7 @@ cloud_properties:
 
 ### Reference pipeline to test a CPI with all combinations of the Director, CLI and  Stemcell
 This pipeline will use all permutations of the V1 and V2 contracts for the director, CLI and stemcell:
-[Pipeline for CPI V2 testing](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/blob/49447ba7ee208c31dddc1b7e3ec2a5f05c88ea99/ci/pipeline_cpi_v2.yml.erb)
+[Pipeline for CPI V2 testing](https://github.com/cloudfoundry/bosh-aws-cpi-release/blob/49447ba7ee208c31dddc1b7e3ec2a5f05c88ea99/ci/pipeline_cpi_v2.yml.erb)
 
 **NOTE:** A few other factors must be considered.
 

--- a/content/vsphere-cpi.md
+++ b/content/vsphere-cpi.md
@@ -377,7 +377,7 @@ with your vSphere resource pool(s).
 
 * Setting `enable_auto_anti_affinity_drs_rules` to true may cause `bosh deploy` to fail after the initial deployment if there are more VMs than hosts. A workaround is to set `enable_auto_anti_affinity_drs_rules` to false to perform subsequent deployments.
 
-* Support for specifying Datastore Clusters for ephemeral and persistent disks is available with vSphere CPI version v47 and above. For additional detais see [Release Notes for v47](https://github.com/cloudfoundry-incubator/bosh-vsphere-cpi-release/releases/tag/v47)
+* Support for specifying Datastore Clusters for ephemeral and persistent disks is available with vSphere CPI version v47 and above. For additional detais see [Release Notes for v47](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/releases/tag/v47)
 
 ### VMs {: #vms }
 


### PR DESCRIPTION
Replace cloudfoundry-incubator by cloudfoundry for all CPIs that recently graduated from incubation.