### PR TITLE
Add new section describing Deployment Convergence behavior

### DIFF
--- a/content/cli-v2.md
+++ b/content/cli-v2.md
@@ -854,6 +854,8 @@ See [CPI config](cpi-config.md).
     bosh -e vbox -d cf recreate diego-cell/209c42e5-3c1a-432a-8445-ab8d7c9f69b0 --skip-drain
     bosh -e vbox -d cf recreate diego-cell --canaries=0 --max-in-flight=100%
     ```
+    !!! warning
+        In case of a **failed** deployment, running `bosh recreate` will converge to the last **successfully deployed state**, not the intended state of the failed deployment. See [Deployment Convergence](deployment-convergence.md).
 
 #### Restart {: #restart }
 
@@ -865,6 +867,9 @@ See [CPI config](cpi-config.md).
     - `--canaries=` flag overrides manifest values for `canaries`
     - `--max-in-flight=` flag overrides manifest values for `max_in_flight`
 
+    !!! warning
+        In case of a **failed** deployment, running `bosh restart` will converge to the last **successfully deployed state**, not the intended state of the failed deployment. See [Deployment Convergence](deployment-convergence.md).
+
 #### Start {: #start }
 
 - `bosh -e my-env -d my-dep start [group[/instance-id]] [--canaries=] [--max-in-flight=]`
@@ -873,6 +878,9 @@ See [CPI config](cpi-config.md).
 
     - `--canaries=` flag overrides manifest values for `canaries`
     - `--max-in-flight=` flag overrides manifest values for `max_in_flight`
+
+    !!! warning
+        In case of a **failed** deployment, running `bosh start` will converge to the last **successfully deployed state**, not the intended state of the failed deployment. See [Deployment Convergence](deployment-convergence.md).
 
 #### Stop {: #stop }
 
@@ -1315,7 +1323,7 @@ See [CPI config](cpi-config.md).
     Cleans up unused resources but keeps orphaned disks and the two most recent versions of stemcells and releases.
 
     - `--all` flag cleans up all unused resources including orphaned disks.
-    
+
     Note that orphan disks get deleted after a few days by default. See [Orphan Disks](persistent-disks.md#orphaned-disks) for more details.
 
 

--- a/content/deployment-convergence.md
+++ b/content/deployment-convergence.md
@@ -1,0 +1,12 @@
+During deployment, bosh tries to converge to the _intended_ state, _i.e._ the state described in the deployment manifest, from the current state.
+
+When a VM recreation is triggered by using `bosh cck` or `bosh restart`/`bosh recreate`, leads to different _intended_ states.
+
+## bosh cck
+
+`bosh cck` will always recreate the instance with the **current** deployed instance state. This means that the desired instance plan is based off of the information that is encoded in the instances' **current** deployment spec that is present in the database.
+
+## bosh restart and bosh recreate
+
+`bosh restart` and `bosh recreate` will always recreate the instance with the last **successfully** deployed desired state. This means that the desired instance plan is based off of the information that is persisted in the last **successfully** deployed manifest. These commands will also detect any changes on other instances that conflict with the last deployed successful state, and attempt to converge the deployment to the desired state.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -212,6 +212,7 @@ pages:
         - Post-stop: post-stop.md
     - Links:
       - Common Types: links-common-types.md
+    - Deployment Convergence: deployment-convergence.md
   - Operating Systems:
     - Ubuntu: ubuntu-os.md
     - Windows Server: windows-os.md


### PR DESCRIPTION
... and warnings on `bosh recreate`, `bosh restart` and `bosh start` CLI commands,
linking to the Deployment Convergence page.

[#164486755](https://www.pivotaltracker.com/story/show/164486755)