### PR TITLE
Use a xenial stemcell in bosh-lite guides

### DIFF
--- a/content/bosh-lite.md
+++ b/content/bosh-lite.md
@@ -96,8 +96,8 @@ Run through quick steps below or follow [deploy workflow](basic-workflow.md) tha
 
     ```shell
     bosh -e vbox upload-stemcell \
-      https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent?v=3586.24 \
-      --sha1 32c1e09391d509d24026e55555df07a166f8b8eb
+      https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-xenial-go_agent?v=315.45 \
+      --sha1 674cd3c1e64d8c51e62770697a63c07ca04e9bbd
     ```
 
 1. Deploy example deployment

--- a/content/quick-start.md
+++ b/content/quick-start.md
@@ -79,8 +79,8 @@ Run through quick steps below or follow [deploy workflow](basic-workflow.md) tha
 1. Upload stemcell
 
     ```shell
-    bosh -e vbox upload-stemcell https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-trusty-go_agent?v=3468.17 \
-      --sha1 1dad6d85d6e132810439daba7ca05694cec208ab
+    bosh -e vbox upload-stemcell https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-xenial-go_agent?v=315.45 \
+      --sha1 674cd3c1e64d8c51e62770697a63c07ca04e9bbd
     ```
 
 1. Deploy example deployment


### PR DESCRIPTION
bosh-lite guides use the zookeeper deployment as a sample
deployment. Meanwhile requires the zookeeper deployments a xenial stemcell.
That is why the current bosh-lite guides don't work.