### PR TITLE
Add documentation for lifecycle placement rule

### DIFF
--- a/content/runtime-config.md
+++ b/content/runtime-config.md
@@ -122,6 +122,7 @@ Available rules:
     * **name** [String, required]: Matching job name.
     * **release** [String, required]: Matching release name.
 * **instance_groups** [Array of strings, optional]: Matches based on instance group names. Available in bosh-release v268+.
+* **lifecycle** [String, optional]: Matches based on lifecycle type, either `service` or `errand`. Available in bosh-release v262+.
 * **networks** [Array of strings, optional]: Matches based on network names. Available in bosh-release v262+.
 * **teams** [Array of strings, optional]: Matches based on team names. Available in bosh-release v253+.
 

--- a/content/runtime-config.md
+++ b/content/runtime-config.md
@@ -122,7 +122,7 @@ Available rules:
     * **name** [String, required]: Matching job name.
     * **release** [String, required]: Matching release name.
 * **instance_groups** [Array of strings, optional]: Matches based on instance group names. Available in bosh-release v268+.
-* **lifecycle** [String, optional]: Matches based on lifecycle type, either `service` or `errand`. Available in bosh-release v262+.
+* **lifecycle** [String, optional]: Matches based on lifecycle type, either `service` or `errand`. Note that a service VM is any non-errand VM and that colocated errands may actually run on service VMs. Available in bosh-release v262+.
 * **networks** [Array of strings, optional]: Matches based on network names. Available in bosh-release v262+.
 * **teams** [Array of strings, optional]: Matches based on team names. Available in bosh-release v253+.
 


### PR DESCRIPTION
The lifecycle placement rule is referenced within the page but not fully documented within the list of placement rules, this just adds that.

As far as I can tell from the commit that added this feature (https://github.com/cloudfoundry/bosh/commit/111df6a1b82b54869a5872db8c58a6314df34624) it looks like v262 is the first release to include the feature but there may be a more definitive way to determine that.