### PR TITLE
Update order of bosh env alias commands

### DIFF
--- a/content/bosh-lite.md
+++ b/content/bosh-lite.md
@@ -55,9 +55,9 @@ Follow below steps to get it running on locally on VirtualBox:
 1. Alias and log into the Director
 
     ```shell
-    bosh alias-env vbox -e 192.168.50.6 --ca-cert <(bosh int ./creds.yml --path /director_ssl/ca)
     export BOSH_CLIENT=admin
     export BOSH_CLIENT_SECRET=`bosh int ./creds.yml --path /admin_password`
+    bosh alias-env vbox -e 192.168.50.6 --ca-cert <(bosh int ./creds.yml --path /director_ssl/ca)
     ```
 
 1. Confirm that it works


### PR DESCRIPTION
Sequence was out of order for creating the bosh alias (not authorized to use `alias-env` before exporting client credentials)