### PR TITLE
Add documentation around `--no-converge` flag on lifecycle commands

### DIFF
--- a/content/cli-v2.md
+++ b/content/cli-v2.md
@@ -875,7 +875,7 @@ See [CPI config](cpi-config.md).
 
 #### Recreate {: #recreate }
 
-- `bosh -e my-env -d my-dep recreate [group[/instance-id]] [--skip-drain] [--fix] [--canaries=] [--max-in-flight=] [--dry-run]`
+- `bosh -e my-env -d my-dep recreate [group[/instance-id]] [--skip-drain] [--fix] [--canaries=] [--max-in-flight=] [--dry-run] [--no-converge] [--converge]`
 
     Recreates VMs for specified instances. Follows typical instance lifecycle.
 
@@ -884,6 +884,8 @@ See [CPI config](cpi-config.md).
     - `--canaries=` flag overrides manifest values for `canaries`
     - `--max-in-flight=` flag overrides manifest values for `max_in_flight`
     - `--dry-run` flag runs through as many operations without altering deployment
+    - `--converge` flag only converges the deployment with the last successful deployment state. This flag is optional and is the default behavior. See [Deployment Convergence](deployment-convergence.md) for more details
+    - `--no-converge` flag only updates the specified instance with current instance state. See [Deployment Convergence](deployment-convergence.md) for more details
 
     ```shell
     bosh -e vbox -d cf recreate
@@ -894,36 +896,40 @@ See [CPI config](cpi-config.md).
     bosh -e vbox -d cf recreate diego-cell --canaries=0 --max-in-flight=100%
     ```
     !!! warning
-        In case of a **failed** deployment, running `bosh recreate` will converge to the last **successfully deployed state**, not the intended state of the failed deployment. See [Deployment Convergence](deployment-convergence.md).
+        In case of a **failed** deployment, running `bosh recreate` without `--no-converge` will converge to the last **successfully deployed state**, not the intended state of the failed deployment. See [Deployment Convergence](deployment-convergence.md).
 
 #### Restart {: #restart }
 
-- `bosh -e my-env -d my-dep restart [group[/instance-id]] [--skip-drain] [--canaries=] [--max-in-flight=]`
+- `bosh -e my-env -d my-dep restart [group[/instance-id]] [--skip-drain] [--canaries=] [--max-in-flight=] [--no-converge] [--converge]`
 
     Restarts jobs (processes) on specified instances. Does not affect VM state.
 
     - `--skip-drain` flag skips running drain scripts; Also skips pre-stop scripts as of director version v270.0.0
     - `--canaries=` flag overrides manifest values for `canaries`
     - `--max-in-flight=` flag overrides manifest values for `max_in_flight`
+    - `--converge` flag only converges the deployment with the last successful deployment state. This flag is optional and is the default behavior. See [Deployment Convergence](deployment-convergence.md) for more details
+    - `--no-converge` flag only updates the specified instance with current instance state. See [Deployment Convergence](deployment-convergence.md) for more details
 
     !!! warning
-        In case of a **failed** deployment, running `bosh restart` will converge to the last **successfully deployed state**, not the intended state of the failed deployment. See [Deployment Convergence](deployment-convergence.md).
+        In case of a **failed** deployment, running `bosh restart` without `--no-converge` will converge to the last **successfully deployed state**, not the intended state of the failed deployment. See [Deployment Convergence](deployment-convergence.md).
 
 #### Start {: #start }
 
-- `bosh -e my-env -d my-dep start [group[/instance-id]] [--canaries=] [--max-in-flight=]`
+- `bosh -e my-env -d my-dep start [group[/instance-id]] [--canaries=] [--max-in-flight=] [--no-converge] [--converge]`
 
     Starts jobs (processes) on specified instances. Does not affect VM state.
 
     - `--canaries=` flag overrides manifest values for `canaries`
     - `--max-in-flight=` flag overrides manifest values for `max_in_flight`
+    - `--converge` flag only converges the deployment with the last successful deployment state. This flag is optional and is the default behavior. See [Deployment Convergence](deployment-convergence.md) for more details
+    - `--no-converge` flag only updates the specified instance with current instance state. See [Deployment Convergence](deployment-convergence.md) for more details
 
     !!! warning
-        In case of a **failed** deployment, running `bosh start` will converge to the last **successfully deployed state**, not the intended state of the failed deployment. See [Deployment Convergence](deployment-convergence.md).
+        In case of a **failed** deployment, running `bosh start` without `--no-converge` will converge to the last **successfully deployed state**, not the intended state of the failed deployment. See [Deployment Convergence](deployment-convergence.md).
 
 #### Stop {: #stop }
 
-- `bosh -e my-env -d my-dep stop [group[/instance-id]] [--skip-drain] [--canaries=] [--max-in-flight=]`
+- `bosh -e my-env -d my-dep stop [group[/instance-id]] [--skip-drain] [--canaries=] [--max-in-flight=] [--no-converge] [--converge]`
 
     Stops jobs (processes) on specified instances. Does not affect VM state unless `--hard` flag is specified.
 
@@ -931,6 +937,11 @@ See [CPI config](cpi-config.md).
     - `--skip-drain` flag skips running drain scripts; Also skips pre-stop scripts as of director version v270.0.0
     - `--canaries=` flag overrides manifest values for `canaries`
     - `--max-in-flight=` flag overrides manifest values for `max_in_flight`
+    - `--converge` flag only converges the deployment with the last successful deployment state. This flag is optional and is the default behavior. See [Deployment Convergence](deployment-convergence.md) for more details
+    - `--no-converge` flag only updates the specified instance with current instance state. See [Deployment Convergence](deployment-convergence.md) for more details
+
+    !!! warning
+        In case of a **failed** deployment, running `bosh stop` without `--no-converge` will converge to the last **successfully deployed state**, not the intended state of the failed deployment. See [Deployment Convergence](deployment-convergence.md).
 
 #### Ignore {: #ignore }
 

--- a/content/deployment-convergence.md
+++ b/content/deployment-convergence.md
@@ -1,12 +1,31 @@
-During deployment, bosh tries to converge to the _intended_ state, _i.e._ the state described in the deployment manifest, from the current state.
+During a deployment, BOSH tries to converge to the _intended_ state, _i.e._ the
+state described in the deployment manifest, from the current state.
 
-When a VM recreation is triggered by using `bosh cck` or `bosh restart`/`bosh recreate`, leads to different _intended_ states.
+When a update is triggered using `bosh cck` or `bosh
+<start|stop|restart|recreate>`, they can lead to different _intended_ states.
 
 ## bosh cck
 
-`bosh cck` will always recreate the instance with the **current** deployed instance state. This means that the desired instance plan is based off of the information that is encoded in the instances' **current** deployment spec that is present in the database.
+`bosh cck` will always recreate the instance with the **current** deployed
+instance state. This means that the desired instance plan is based off of the
+information that is encoded in the instances' **current** deployment spec that
+is present in the database.
 
-## bosh restart and bosh recreate
+## bosh <start|stop|restart|recreate\>
 
-`bosh restart` and `bosh recreate` will always recreate the instance with the last **successfully** deployed desired state. This means that the desired instance plan is based off of the information that is persisted in the last **successfully** deployed manifest. These commands will also detect any changes on other instances that conflict with the last deployed successful state, and attempt to converge the deployment to the desired state.
+`bosh <start|stop|restart|recreate>` will always converge the instance to the
+last **successfully** deployed desired state. This means that the desired
+instance plan is based off of the information that is persisted in the last
+**successfully** deployed manifest. These commands will also detect any changes
+on other instances that conflict with the last deployed successful state, and
+attempt to converge the deployment to the desired state.
 
+### --no-converge flag
+
+As of [BOSH
+v270.4.0](https://github.com/cloudfoundry/bosh/releases/tag/v270.4.0) and [BOSH
+CLI v6.0.0](https://github.com/cloudfoundry/bosh-cli/releases/tag/v6.0.0), the
+`start`, `stop`, `restart`, and `recreate` commands all support a
+`--no-converge` flag. When this flag is specified, the corresponding command
+will act **ONLY** on the specified instance. The instance will based off of the
+**current** deployed instance state that is recorded in the database.


### PR DESCRIPTION
[finishes #167578414](https://www.pivotaltracker.com/story/show/167578414)

Co-authored-by: Miguel Verissimo <mverissimo@pivotal.io>