### PR TITLE
Document new `clean-up` behavior on releases on cloud configs

### DIFF
--- a/content/cli-v2.md
+++ b/content/cli-v2.md
@@ -1392,7 +1392,9 @@ See [CPI config](cpi-config.md).
 
     - `--all` flag cleans up all unused resources including orphaned disks.
 
-    Note that orphan disks get deleted after a few days by default. See [Orphan Disks](persistent-disks.md#orphaned-disks) for more details.
+    Orphan disks get deleted after a few days by default. See [Orphan Disks](persistent-disks.md#orphaned-disks) for more details.
+
+    **Note:** From BOSH v270.xxx, releases specified in runtime configs are considered 'in use' and won't be deleted by running `bosh clean-up [--all]`.
 
 
 #### Help {: #help }

--- a/content/cli-v2.md
+++ b/content/cli-v2.md
@@ -1394,7 +1394,7 @@ See [CPI config](cpi-config.md).
 
     Orphan disks get deleted after a few days by default. See [Orphan Disks](persistent-disks.md#orphaned-disks) for more details.
 
-    **Note:** From BOSH v270.xxx, releases specified in runtime configs are considered 'in use' and won't be deleted by running `bosh clean-up [--all]`.
+    **Note:** From BOSH v270.5.0, releases specified in runtime configs are considered 'in use' and won't be deleted by running `bosh clean-up [--all]`.
 
 
 #### Help {: #help }


### PR DESCRIPTION
@mfine30 Note the BOSH v270.xxx placeholder than will need to be changed

[#167795212](https://www.pivotaltracker.com/story/show/167795212)