### PR TITLE
Remove extra characters from the windows bosh monit file

### DIFF
--- a/content/windows.md
+++ b/content/windows.md
@@ -65,8 +65,8 @@ For instance, to use separate scripts for start and stop:
       "executable": "powershell.exe",
       "args": [ "/var/vcap/jobs/say-hello/bin/start.ps1" ],
       "stop": {
-        "executable": "powershell.exe",:
-        "args": [ "/var/vcap/jobs/say-hello/bin/stop.ps1" ],
+        "executable": "powershell.exe",
+        "args": [ "/var/vcap/jobs/say-hello/bin/stop.ps1" ]
       }
     }
   ]


### PR DESCRIPTION
The example monit file for windows looks to have some syntax issues. This PR removes those extras. 