### PR TITLE
Favor `name` over `final_name` for in config/final.yml

### DIFF
--- a/content/create-release.md
+++ b/content/create-release.md
@@ -646,11 +646,11 @@ Example `final.yml`:
 
 ```yaml
 ---
+name: ardo_app
 blobstore:
   provider: local
   options:
     blobstore_path: /tmp/ardo-blobs
-final_name: ardo_app
 ```
 
 Example `private.yml`:


### PR DESCRIPTION
Hi Bosh fellows!

In this PR, I would like us to advertise the use of the newer `name` property in `config/final.yml` file, over the historical `final_name`.

Worth to mention, this new property name has already been adopted by the template used by `bosh init-release` to generate the default `config/final.yml` file.

Best,
Benjamin