### PR TITLE
Revise UAA example configuration

### DIFF
--- a/content/director-users-uaa.md
+++ b/content/director-users-uaa.md
@@ -54,6 +54,12 @@ In this configuration the Director is configured to delegate user management to 
             - bosh.admin
 
         clients:
+          admin:
+            authorities: bosh.admin
+            authorized-grant-types: client_credentials
+            override: true
+            scope: ""
+            secret: ((admin_password))
           bosh_cli:
             override: true
             authorized-grant-types: password,refresh_token
@@ -66,8 +72,6 @@ In this configuration the Director is configured to delegate user management to 
 
         admin:
           # client_secret: admin-password # <--- Uncomment & change
-        login:
-          # client_secret: login-password # <--- Uncomment & change
         zones: {internal: {hostnames: []}}
     ```
 

--- a/content/director-users-uaa.md
+++ b/content/director-users-uaa.md
@@ -149,6 +149,17 @@ In this configuration the Director is configured to delegate user management to 
         - Public key used to verify tokens (e.g. `./uaa.pub`)
     - `director.user_management.uaa.public_key`
         - Public key used by the Director to verify tokens without contacting the UAA (e.g. `./uaa.pub`)
+        
+1. Add UAA encryption key:
+
+    ```yaml
+    properties:
+      encryption:
+        active_key_label: "uaa-encryption-key"
+        encryption_keys:
+        - label: "uaa-encryption-key"
+          passphrase: "ENTER-PASSPHRASE"
+    ```
 
 1. Allow access to port 8443 on the Director VM from your IaaS so that the CLI can access the UAA server.
 


### PR DESCRIPTION
* add `admin` user to `clients` section (see https://github.com/cloudfoundry/bosh-deployment/blob/85d2f2122bfc2c1f5184c4b10224705fe22d8113/uaa.yml#L40)
* remove outdated property `login` (see https://github.com/cloudfoundry/cf-deployment/issues/85)
* add missing `encryption` block to example