### PR TITLE
Deployment polishing

### DIFF
--- a/content/deploying.md
+++ b/content/deploying.md
@@ -1,4 +1,4 @@
-Once referenced stemcells and releases are uploaded to the Director and the deployment manifest is complete, Director can successfull make a deployment. The CLI has a single command to create and update a deployment: [`bosh deploy` command](cli-v2.md#deploy). From the perspective of the Director same steps are taken to create or update a deployment.
+Once the deployment manifest is complete and the referenced stemcells and releases are uploaded to the Director, we are ready to proceed with the deployment. The CLI has a single command to create and update a deployment: [`bosh deploy` command](cli-v2.md#deploy). From the Detector perspective the same steps are taken to create or update a deployment.
 
 To create a Zookeeper deployment from `zookeeper.yml` deployment manifest run the deploy command:
 

--- a/content/deploying.md
+++ b/content/deploying.md
@@ -1,4 +1,4 @@
-Once the deployment manifest is complete and the referenced stemcells and releases are uploaded to the Director, we are ready to proceed with the deployment. The CLI has a single command to create and update a deployment: [`bosh deploy` command](cli-v2.md#deploy). From the Detector perspective the same steps are taken to create or update a deployment.
+Once the deployment manifest is complete and the referenced stemcells and releases are uploaded to the Director, we are ready to proceed with the deployment. The CLI has a single command to create and update a deployment: [`bosh deploy` command](cli-v2.md#deploy). From the Director perspective the same steps are taken to create or update a deployment.
 
 To create a Zookeeper deployment from `zookeeper.yml` deployment manifest run the deploy command:
 


### PR DESCRIPTION
* Moved deployment manifest in front of releases and stemcells to clarify that the forth refers to the latter
* Rephrased "Director can successful make a deployment" as we cannot be sure the deployment attempt will be successful
* Rephrased a bit the create and update deployment steps