### PR TITLE
Persistent disk polishing

### DIFF
--- a/content/persistent-disks.md
+++ b/content/persistent-disks.md
@@ -6,10 +6,7 @@ Instance groups may need to store persistent data.
 If you attach a persistent disk to a virtual machine and then delete the VM via `bosh delete-vm`, your
 persistent disk data remains intact. Attaching the persistent disk to another VM allows you to access your data.
 
-***WARNING***: However, if you terminate or delete a VM ***from your IaaS console***, the fate of the persistent
-disk depends on the IaaS provider.  For example 
-* In AWS, the default behavior is to keep the persistent disk when you delete a VM.
-* But in vSphere, the persistent disk is permanently destroyed if you right click and pick "Delete from Disk" on a VM.
+***WARNING***: If you terminate or delete a VM ***from your IaaS console***, the fate of the persistent disk depends on the IaaS provider. For example, in AWS, the default behavior is to keep the persistent disk when you delete a VM. However, if you right click and pick "Delete from Disk" on a VM in vSphere, the persistent disk is permanently destroyed.
 
 Persistent disks are kept for each instance under the following circumstances:
 


### PR DESCRIPTION
* Asterisk chars in warning section do not produce bullet points in the HTML view. Considering this and that we do not plan to share an exhaustive list within the warning, I suggest to rephrase emphasizing those are just two examples of default IaaS behavior.
* Besides, starting a paragraph with "however" (while this word has a proper place later in the paragraph) and bullet points with "For example" does not look like the best style of writing.