### PR TITLE
vsphere cpi cluster host group config format fix

### DIFF
--- a/content/vsphere-cpi.md
+++ b/content/vsphere-cpi.md
@@ -369,6 +369,7 @@ nsx:
   user: administrator@vsphere.local
   password: vmware
 ```
+
 ---
 ## Example Cloud Config {: #cloud-config }
 


### PR DESCRIPTION
* Added newline between end of yaml and start of next section to prevent unwanted yaml font increase