### PR TITLE
Update cli-v2-install.md

### DIFF
--- a/content/cli-v2-install.md
+++ b/content/cli-v2-install.md
@@ -36,7 +36,7 @@ If you are on macOS with [Homebrew](https://brew.sh/), you can install using the
 1. Use `brew` to install `bosh-cli`:
 
     ```shell
-    brew install cloudfoundry/tap/bosh-cli
+    brew install cloudfoundry/homebrew-tap/bosh-cli
     ```
 
 1. You should now be able to use `bosh`. Verify by querying the CLI for its version:


### PR DESCRIPTION
The **brew** command line seems to be wrong. The correct folder is "homebrew-tap" instead of only "tap".

When using the original command you will be ask for the GitHub credentials, but an error will occur even after you typed in a valid user and password.
I tried it on my iMac and the corrected command line worked.