### PR TITLE
Fix: incorrect phrasing

### DIFF
--- a/content/persistent-disks.md
+++ b/content/persistent-disks.md
@@ -53,7 +53,7 @@ instance_groups:
 ```
 
 !!! note
-    If you use persistent disk declaration, you cannot specify the persistent disk type or size that the CPI attaches to your job VMs. Instead, the CPI uses its default disk configuration when deploying the VMs.
+    If you use persistent disk declaration, you cannot specify the persistent disk type that the CPI attaches to your job VMs. Instead, the CPI uses its default disk configuration when deploying the VMs.
 
 ---
 ## Persistent Disk Pool Declaration {: #persistent-disk-pool }


### PR DESCRIPTION
The `persistent_disk` option does allow you to specify size, just not the type.

Slack [context](https://cloudfoundry.slack.com/archives/C02HPPYQ2/p1598298516010000?thread_ts=1598292993.008700&cid=C02HPPYQ2)

@peterhaochen47 and I