### PR TITLE
Update vsphere-cpi.md

### DIFF
--- a/content/vsphere-cpi.md
+++ b/content/vsphere-cpi.md
@@ -224,7 +224,7 @@ Schema:
     * **vm_folder** [String, required]: Path to a folder (relative to the datacenter) for storing created VMs. Folder will be automatically created if not found.
     * **template_folder** [String, required]: Path to a folder (relative to the datacenter) for storing uploaded stemcells. Folder will be automatically created if not found.
     * **disk_path** [String, required]: Path to a *disk* folder for storing persistent disks. Folder will be automatically created in the datastore if not found.
-    * **datastore_pattern** [String, required if `datastore_cluster_pattern` is not set]: Pattern for selecting datastores for storing ephemeral disks and stemcells.
+    * **datastore_pattern** [String, required if `datastore_cluster_pattern` is not set or CPI version <= v63]: Pattern for selecting datastores for storing ephemeral disks and stemcells.
     * **datastore\_cluster\_pattern** [String, required if `datastore_pattern` is not set]: Pattern for selecting datastore clusters for storing ephemeral disks. This feature is experimental. Available in v63+.
     * **persistent\_datastore\_pattern** [String, required if `persistent_datastore_cluster_pattern` is not set]: Pattern for selecting datastores for storing persistent disks.
     * **persistent\_datastore\_cluster\_pattern** [String, required if `persistent_datastore_pattern` is not set]: Pattern for selecting datastore clusters for storing persistent disks. This feature is experimental. Available in v62+.

--- a/content/vsphere-cpi.md
+++ b/content/vsphere-cpi.md
@@ -224,8 +224,8 @@ Schema:
     * **vm_folder** [String, required]: Path to a folder (relative to the datacenter) for storing created VMs. Folder will be automatically created if not found.
     * **template_folder** [String, required]: Path to a folder (relative to the datacenter) for storing uploaded stemcells. Folder will be automatically created if not found.
     * **disk_path** [String, required]: Path to a *disk* folder for storing persistent disks. Folder will be automatically created in the datastore if not found.
-    * **datastore_pattern** [String, required]: Pattern for selecting datastores for storing ephemeral disks and stemcells.
-    * **datastore\_cluster\_pattern** [String]: Pattern for selecting datastore clusters for storing ephemeral disks. This feature is experimental. Available in v63+.
+    * **datastore_pattern** [String, required if `datastore_cluster_pattern` is not set]: Pattern for selecting datastores for storing ephemeral disks and stemcells.
+    * **datastore\_cluster\_pattern** [String, required if `datastore_pattern` is not set]: Pattern for selecting datastore clusters for storing ephemeral disks. This feature is experimental. Available in v63+.
     * **persistent\_datastore\_pattern** [String, required if `persistent_datastore_cluster_pattern` is not set]: Pattern for selecting datastores for storing persistent disks.
     * **persistent\_datastore\_cluster\_pattern** [String, required if `persistent_datastore_pattern` is not set]: Pattern for selecting datastore clusters for storing persistent disks. This feature is experimental. Available in v62+.
     * **clusters** [Array, required]: Array of clusters to use for VM placement.


### PR DESCRIPTION
As of v64, `datastore_pattern` may be omitted if `datastore_cluster_pattern` is set. This commit makes the docs for `datastore_pattern` and `datastore_cluster_pattern` consistent with `persistent_datastore_pattern` and `persistent_datastore_cluster_pattern` now that the behavior is also consistent.