### PR TITLE
Update documentation for signed URLs

### DIFF
--- a/content/director-blobstore-signed-urls.md
+++ b/content/director-blobstore-signed-urls.md
@@ -14,22 +14,25 @@ later, and windows 2019.17 and later.
 
 ### Enabling the feature flag
 
-This feature can be enabled by updating the bosh director manifest with the
+This feature can be enabled by updating the Bosh director manifest with the
 following properties:
 
-* `blobstore.enable_signed_urls`: Set this to true to have the director begin
-  sending signed urls to the agent.
+* `blobstore.enable_signed_urls`: set this to `true` to have the director
+  begin sending signed urls to the agent.
 
-You must continue configuring `blobstore.*` properties, except
-`blobstore.agent.user` and `blobstore.agent.password` that are no more
-necessary. Enabling signed URLs should work alongside blobstore provider
-specific encryption options such as `blobstore.encryption_key` (GCS) and
-`blobstore.sse_kms_key_id` (AWS).
+Enabling signed URLs should work alongside blobstore provider specific
+encryption options such as `blobstore.encryption_key` (GCS) and
+`blobstore.sse_kms_key_id` (AWS S3).
 
-An ops-file in bosh-deployment can be used to enable signed URLs.
+You must continue configuring `blobstore.*` properties. For
+`blobstore.agent.user` and `blobstore.agent.password` you can configure dummy
+values because they are no more used but still required in the configuration
+templates of some CPIs.
+
+An ops-file in bosh-deployment can be used to enable signed URLs and manage
+the unneccesary properites.
 See the [bosh-deployment › misc/blobstore-signed-urls.yml](https://github.com/cloudfoundry/bosh-deployment/blob/master/misc/blobstore-signed-urls.yml)
 ops file.
-This ops-file assumes a DAV blobstore.
 
 ### Removing blobstore credentials from agent VM
 

--- a/content/director-blobstore-signed-urls.md
+++ b/content/director-blobstore-signed-urls.md
@@ -72,6 +72,15 @@ For DAV blobstores, please also configure:
 
 * `blobstore.secret`: The secret used to calculate the signed urls' signature
 
+### Removing blobstore credentials for agent
+
+Once you have ensured that all deployments are using supported stemcells, you
+can safely stop provisioning any user credentials for the agents to access
+the blobstore.
+
+See the [bosh-deployment › misc/remove-local-blobstore-agent-credentials.yml](https://github.com/cloudfoundry/bosh-deployment/blob/master/misc/remove-local-blobstore-agent-credentials.yml)
+ops file.
+
 ## Notes
 
 Additionally, when updating `blobstore.enable_signed_urls` from true to false,

--- a/content/director-blobstore-signed-urls.md
+++ b/content/director-blobstore-signed-urls.md
@@ -74,19 +74,6 @@ For DAV blobstores, please also configure:
 
 * `blobstore.secret`: The secret used to calculate the signed urls' signature
 
-### Removing blobstore credentials for agent
-
-Once you have ensured that all deployments are using supported stemcells, you
-can safely stop provisioning any user credentials for the agents to access
-the blobstore.
-
-Please note that the CPIs, as deployed on the BOSH Director's VM, must have
-support for optional agent credentials on the blobstore. Please refer to the
-release notes of your CPIs to identify the required minimum versions.
-
-See the [bosh-deployment › misc/remove-local-blobstore-agent-credentials.yml](https://github.com/cloudfoundry/bosh-deployment/blob/master/misc/remove-local-blobstore-agent-credentials.yml)
-ops file.
-
 ## Notes
 
 Additionally, when updating `blobstore.enable_signed_urls` from true to false,

--- a/content/director-blobstore-signed-urls.md
+++ b/content/director-blobstore-signed-urls.md
@@ -24,7 +24,9 @@ You must continue configuring `blobstore.*` properties. Enabling signed URLs
 should work alongside blobstore provider specific encryption options such as
 `blobstore.encryption_key` (GCS) and `blobstore.sse_kms_key_id` (AWS).
 
-An ops-file in bosh-deployment can be used to enable signed urls. See: https://github.com/cloudfoundry/bosh-deployment/blob/master/enable-signed-urls.yml
+An ops-file in bosh-deployment can be used to enable signed urls.
+See the [bosh-deployment › misc/blobstore-signed-urls.yml](https://github.com/cloudfoundry/bosh-deployment/blob/master/misc/blobstore-signed-urls.yml)
+ops file.
 This ops-file assumes a DAV blobstore.
 
 ### Removing blobstore credentials from agent VM

--- a/content/director-blobstore-signed-urls.md
+++ b/content/director-blobstore-signed-urls.md
@@ -80,6 +80,10 @@ Once you have ensured that all deployments are using supported stemcells, you
 can safely stop provisioning any user credentials for the agents to access
 the blobstore.
 
+Please note that the CPIs, as deployed on the BOSH Director's VM, must have
+support for optional agent credentials on the blobstore. Please refer to the
+release notes of your CPIs to identify the required minimum versions.
+
 See the [bosh-deployment › misc/remove-local-blobstore-agent-credentials.yml](https://github.com/cloudfoundry/bosh-deployment/blob/master/misc/remove-local-blobstore-agent-credentials.yml)
 ops file.
 

--- a/content/director-blobstore-signed-urls.md
+++ b/content/director-blobstore-signed-urls.md
@@ -20,11 +20,13 @@ following properties:
 * `blobstore.enable_signed_urls`: Set this to true to have the director begin
   sending signed urls to the agent.
 
-You must continue configuring `blobstore.*` properties. Enabling signed URLs
-should work alongside blobstore provider specific encryption options such as
-`blobstore.encryption_key` (GCS) and `blobstore.sse_kms_key_id` (AWS).
+You must continue configuring `blobstore.*` properties, except
+`blobstore.agent.user` and `blobstore.agent.password` that are no more
+necessary. Enabling signed URLs should work alongside blobstore provider
+specific encryption options such as `blobstore.encryption_key` (GCS) and
+`blobstore.sse_kms_key_id` (AWS).
 
-An ops-file in bosh-deployment can be used to enable signed urls.
+An ops-file in bosh-deployment can be used to enable signed URLs.
 See the [bosh-deployment › misc/blobstore-signed-urls.yml](https://github.com/cloudfoundry/bosh-deployment/blob/master/misc/blobstore-signed-urls.yml)
 ops file.
 This ops-file assumes a DAV blobstore.


### PR DESCRIPTION
This work relates to:
- cloudfoundry/bosh-deployment#423
- cloudfoundry/bosh#2327
- cloudfoundry/bosh-davcli#12
- cloudfoundry/bosh-aws-cpi-release#118
- cloudfoundry/bosh-google-cpi-release#327
- cloudfoundry/bosh-azure-cpi-release#642
- cloudfoundry-incubator/bosh-alicloud-cpi-release#148
- cloudfoundry/bosh-openstack-cpi-release#242

Here we mention the possible removal of unnecessary agent creds for accessing the blobstore.

We also update the documentation after moving the `enable-signed-urls.yml` ops file to `misc/blobstore-signed-urls.yml`.