### PR TITLE
Remove mention of compiled_package_cache

### DIFF
--- a/content/cli-v2.md
+++ b/content/cli-v2.md
@@ -191,8 +191,7 @@ See [Environments](cli-envs.md).
     UUID      eeb27cc6-467e-4c1d-a8f9-f1a8de759f52
     Version   260.5.0 (00000000)
     CPI       warden_cpi
-    Features  compiled_package_cache: disabled
-              dns: disabled
+    Features  dns: disabled
               snapshots: disabled
     User      admin
 

--- a/content/managed-networks.md
+++ b/content/managed-networks.md
@@ -31,8 +31,7 @@ Name      p-bosh
 UUID      b16a53aa-c426-4b5c-b7bd-b7e28eb28df1
 Version   268.5.0 (00000000)
 CPI       vsphere_cpi
-Features  compiled_package_cache: enabled
-          config_server: enabled
+Features  config_server: enabled
           dns: disabled
           network_lifecycle: enabled
           snapshots: disabled


### PR DESCRIPTION
compiled_package_cache is going to get removed once
https://github.com/cloudfoundry/bosh/pull/2338
is merged. This PR Updates the docs to remove mentions of compiled_package_cache.