### PR TITLE
docs: update Windows Stemcell OS page

### DIFF
--- a/content/windows-os.md
+++ b/content/windows-os.md
@@ -1,20 +1,25 @@
 # Stemcell OS: Microsoft Windows Server
 
-The Microsoft Windows images are built from the [cloudfoundry-incubator/bosh-windows-stemcell-builder](https://github.com/cloudfoundry-incubator/bosh-windows-stemcell-builder) repository.
-
+The Microsoft Windows images are built from the [cloudfoundry/stembuild](https://github.com/cloudfoundry/stembuild) repository. Previously, they were built from [cloudfoundry/bosh-windows-stemcell-builder](https://github.com/cloudfoundry/bosh-windows-stemcell-builder) (deprecated).
 
 ## Distributions
+
+### Windows Server 2019
+
+You can find the official stemcells from [bosh.io/stemcells](https://bosh.io/stemcells#windows2019).
+
+### Windows Server 1803
+
+You can find the official stemcells from [bosh.io/stemcells](https://bosh.io/stemcells#windows1803).
 
 ### Windows Server 2016
 
 You can find the official stemcells from [bosh.io/stemcells](https://bosh.io/stemcells#windows2016).
 
-
 ### Windows Server 2012 R2
 
 You can find the official stemcells from [bosh.io/stemcells](https://bosh.io/stemcells#windows2012R2).
 
-
 ## Licensing
 
-Windows stemcells will have additional costs associated with Microsoft licensing; they do not include actual Windows OS. When using light stemcells on public clouds, additional costs will be associated with your virtual machine. For more information on building Windows stemcells and running in on-premise environments, please see this [Getting Started](https://github.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/wiki/BOSH-Windows-Getting-Started-Guide) guide.
+Windows stemcells will have additional costs associated with Microsoft licensing; they do not include actual Windows OS. When using light stemcells on public clouds, additional costs will be associated with your virtual machine. For more information on building Windows stemcells and running in on-premise environments, please see this [Creating a Windows Stemcell for vSphere Using stembuild](./windows-stemcell-create.md) and [Getting Started](https://github.com/cloudfoundry-incubator/bosh-windows-stemcell-builder/wiki/BOSH-Windows-Getting-Started-Guide) (deprecated) guide.


### PR DESCRIPTION
- Add 1803 and 2019 distributions
- Add reference to `stembuild`
- Document deprecation of `bosh-windows-stemcell-builder`

Reference to the deprecated repository is kept for posterity as:

- There are no replacements for building OpenStack Windows Stemcells and
- There are no other references to `bosh-windows-stemcell-builder`

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>