### PR TITLE
Remove mention of permit nats access

### DIFF
--- a/content/tips.md
+++ b/content/tips.md
@@ -52,22 +52,7 @@ For a more detailed error report, run: bosh task 45 --debug
 
 This problem can occur due to:
 
-- blocked network connectivity between the Agent on a new VM and NATS (typically the Director VM). For stemcells newer than Xenial 621.178, Xenial 456.209, and Bionic 1.40, additional restrictions can block connectivity to NATS, specifically, traffic to the NATS endpoint is restricted to membership in a specific **cgroup**. To work around this restriction, follow these steps:
-    ```shell
-    # To add your SSH Session to the NATS Access CGROUP you can execute the below steps.
-    # This will work EXCLUSIVELY for the SSH Session that executes the command and does
-    # not persist across SSH Sessions/Connections.
-    # Once SSH'ed onto a failing VM
-    # DIRECTOR IP // NATS IP == 10.0.0.6
-    nc 10.0.0.6 4222 -v
-    # (times out)
-    sudo su
-    source /var/vcap/bosh/etc/nats-access-helper.sh
-    permit_nats_access
-    nc 10.0.0.6 4222 -v
-    # Connection to 10.0.0.6 4222 port [tcp/*] succeeded!
-    # INFO {....}
-    ```
+- blocked network connectivity between the Agent on a new VM and NATS (typically the Director VM).
 - bootstrapping problem on the VM and/or wrong configuration of the Agent
 - blocked or slow boot times of the VM
 


### PR DESCRIPTION
We pulled the Nats-FW implementation from the stemcell builder since it didn't work properly across IaaSs. 
When reverting the changes in the stemcell builder, we forgot to remove this section from the docs.  
These additional debugging steps relate to a script that got removed when the feature was reverted 
from the stemcell builder. These steps currently won't work since neither the script nor the cgroup is on 
bosh deployed VMs. 

There is work around re-adding the FW functionality via the bosh-agent. This section will be re-updated
with the proper steps once the stemcell containing the new agent versions is released.