### PR TITLE
Remove unneccessary vars generation

### DIFF
--- a/content/nats-ca-rotation.md
+++ b/content/nats-ca-rotation.md
@@ -156,49 +156,6 @@ bosh create-env ~/workspace/bosh-deployment/bosh.yml \
     certificate: ((nats_clients_health_monitor_tls_2.certificate))
     private_key: ((nats_clients_health_monitor_tls_2.private_key))
 
-- type: replace
-  path: /variables/-
-  value:
-    name: nats_ca_2
-    type: certificate
-    options:
-      is_ca: true
-      common_name: default.nats-ca.bosh-internal
-
-- type: replace
-  path: /variables/-
-  value:
-    name: nats_server_tls_2
-    type: certificate
-    options:
-      ca: nats_ca_2
-      common_name: default.nats.bosh-internal
-      alternative_names: [((internal_ip))]
-      extended_key_usage:
-      - server_auth
-
-- type: replace
-  path: /variables/-
-  value:
-    name: nats_clients_director_tls_2
-    type: certificate
-    options:
-      ca: nats_ca_2
-      common_name: default.director.bosh-internal
-      extended_key_usage:
-      - client_auth
-
-- type: replace
-  path: /variables/-
-  value:
-    name: nats_clients_health_monitor_tls_2
-    type: certificate
-    options:
-      ca: nats_ca_2
-      common_name: default.hm.bosh-internal
-      extended_key_usage:
-      - client_auth
-
 ```
 
 


### PR DESCRIPTION
In the second ops file, the /variables do not need to be touched. The only 2 cases where they could be not there would be:
- You run Step3 before step 1
- You forget to remove the ops after step 5

This way in both cases the bosh deploy errors and will not cause all VMs to lose connection to BOSH. We internally use it like this for quite a while now and it prevented some incidents already so I think everyone should have that.