### PR TITLE
Document `create` as value of version in manifest

### DIFF
--- a/content/manifest-v2.md
+++ b/content/manifest-v2.md
@@ -63,8 +63,8 @@ features:
 **releases** [Array, required]: The name and version of each release in the deployment.
 
 * **name** [String, required]: Name of a release used in the deployment.
-* **version** [String, required]: The version of the release to use. Version can be `latest`.
-* **url** [String, optional]: URL of a release to download. Works with CLI v2. Example: `https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11`.
+* **version** [String, required]: The version of the release to use. Version can be `latest` or `create`.
+* **url** [String, optional]: URL of a release to download or local directory path when version is `create`. Works with CLI v2. Example: `https://bosh.io/d/github.com/cloudfoundry/syslog-release?v=11`.
 * **sha1** [String, optional]: SHA1 of asset referenced via URL. Works with CLI v2. Example: `332ac15609b220a3fdf5efad0e0aa069d8235788`.
 * **stemcell** [Hash, optional]: When `url` refers to a compiled release, the stemcell on which it was compiled (recommended when `url` refers to a compiled release).
     * **os** [String, required]: Operating system of the stemcell. Example: `ubuntu-xenial`.


### PR DESCRIPTION
I learned this trick from @acrmp but it usually takes me two tries to remember where create goes and how to specify the local path to the bosh release directory.