### PR TITLE
update cli-v2-install with instructions for jammy

### DIFF
--- a/content/cli-v2-install.md
+++ b/content/cli-v2-install.md
@@ -60,15 +60,9 @@ When you are using `bosh` to bootstrap BOSH or other standalone VMs, you will ne
 
 ### Ubuntu
 
-If you are running on Ubuntu Xenial (16.04) or Ubuntu Trusty (14.04), ensure the following packages are installed on your system:
-
+For Ubuntu Jammy (22.04), ensure the following packages are installed on your system:
 ```shell
-sudo apt-get install -y build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3
-```
-
-For Ubuntu Bionic (18.04), ensure the following packages are installed on your system:
-```shell
-sudo apt-get install -y build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt1-dev libxml2-dev libssl-dev libreadline7 libreadline-dev libyaml-dev libsqlite3-dev sqlite3
+sudo apt-get install -y build-essential zlib1g-dev ruby ruby-dev openssl libxslt1-dev libxml2-dev libssl-dev libreadline-dev libyaml-dev libsqlite3-dev sqlite3
 ```
 
 ### macOS


### PR DESCRIPTION
The packages required for jammy are slightly different. The old instructions are confusing people.