### PR TITLE
Document default tags for VMs and disks

### DIFF
--- a/content/cpi-api-v2-method/create-vm.md
+++ b/content/cpi-api-v2-method/create-vm.md
@@ -10,7 +10,7 @@ As of V2 of the CPI API contract, `create_vm` returns an array of the resultant 
 
 As of V2, created VMs can be tagged at creation time. Please note that the
 `director`, `deployment`, `instance_group`, `job`, `id`, `name`, `index` and
-`created_at` default tags enforced by Bosh, that cannot be overridden. See
+`created_at` are default tags enforced by Bosh that cannot be overridden. See
 also the [`set_vm_metadata` CPI method](set-vm-metadata.md) for more info
 about default tags.
 

--- a/content/cpi-api-v2-method/create-vm.md
+++ b/content/cpi-api-v2-method/create-vm.md
@@ -8,6 +8,13 @@ If the VM's creation fails, please make sure to properly delete the associated r
 
 As of V2 of the CPI API contract, `create_vm` returns an array of the resultant instance ID and the networks associated with the VM.
 
+As of V2, created VMs can be tagged at creation time. Please note that the
+`director`, `deployment`, `instance_group`, `job`, `id`, `name`, `index` and
+`created_at` default tags enforced by Bosh, that cannot be overridden. See
+also the [`set_vm_metadata` CPI method](set-vm-metadata.md) for more info
+about default tags.
+
+
 
 ## Arguments
 

--- a/content/cpi-api-v2-method/set-disk-metadata.md
+++ b/content/cpi-api-v2-method/set-disk-metadata.md
@@ -4,8 +4,23 @@ Sets disk's metadata to make it easier for operators to categorize disks when lo
 
 Disk metadata is written when the disk is attached to a VM. Metadata is not removed when disk is detached or VM is deleted.
 
+What is called “_metadata_” here is actually implemented as tags by most CPIs.
+The following default disk tags are forced by Bosh, whatever happens. These
+cannot be overridden.
+
+```json
+{
+  "instance_id":    "c50f32a0-65f4-40a2-9dde-bff12560c14d", // the stable, unique ID of the (VM) instance in its group, to which the disk has been attached
+  "instance_index": "1",                                    // the human-readable identifier of the (VM) instance in its instance group
+  "attached_at":    "YYYY-MM-DDThh:mm:ssZ",                 // the last time at which `set_disk_metadata` method has been called on the disk
+  "instance_group": "traefik",       // the name of the group to which the (VM) instance belongs
+  "deployment":     "traefik",       // the name of deployment to which the 'instance_group' belongs
+  "director":       "director name", // the name of the director that has deployed the deployment, as shown by `bosh env`
+}
+```
+
 !!! note
-    This method is called by BOSH v262+.
+    This `set_disk_metadata` method is called by BOSH v262+.
 
 
 ## Arguments

--- a/content/cpi-api-v2-method/set-vm-metadata.md
+++ b/content/cpi-api-v2-method/set-vm-metadata.md
@@ -2,8 +2,33 @@
 
 Sets VM's metadata to make it easier for operators to categorize VM-based resources when looking at the IaaS management console. We recommend to set VM name based on the passed `name` key (note `name` may be missing).
 
-For example AWS CPI uses tags to store metadata for operators to see in the AWS Console.
+For example AWS CPI uses tags to store metadata for operators to see in the AWS
+Console. Same goes for Azure and Google CPIs. What is called “_metadata_” here
+is actually implemented as tags by most CPIs.
 
+The following default tags are forced by Bosh, whatever happens. These cannot be overridden.
+
+```json
+{
+  "director":       "director name", // the director name, as shown by `bosh env`
+  "deployment":     "traefik",       // the name of deployment to which the 'instance_group' belongs
+  "instance_group": "traefik",       // the name of the group to which the (VM) instance belongs
+  "job":            "traefik",       // 'job' is an old alias for 'instance_group', here it holds the exact same value
+  "id":    "c50f32a0-65f4-40a2-9dde-bff12560c14d",         // the stable, unique ID of the (VM) instance in its group
+  "name":  "traefik/c50f32a0-65f4-40a2-9dde-bff12560c14d", // the full name of the (VM) instance, composed of '<instance_group>/<instance_id>'
+  "index": "1",                                            // the human-readable identifier of the (VM) instance in its instance group
+  "created_at": "YYYY-MM-DDThh:mm:ssZ"                     // the last time at which `set_vm_metadata` method has been called on the (VM) instance
+}
+```
+
+Compilation VMs also have this tag that details the package being compiled by
+the VM:
+
+```json
+{
+  "compiling": "package name"
+}
+```
 
 ## Arguments
 

--- a/content/manifest-v2.md
+++ b/content/manifest-v2.md
@@ -332,6 +332,18 @@ See [CLI Variable Interpolation](cli-int.md) for more details about variables.
 
 **tags** [Hash, optional]: Specifies key value pairs to be sent to the CPI for VM and disk tagging. Combined with runtime config level tags during the deploy. Available in bosh-release v258+.
 
+Both VMs and disks get tagged by these custom tags.
+
+For VMs, the `director`, `deployment`, `instance_group`, `job`, `id`, `name`,
+`index` and `created_at` default tags enforced by Bosh, that cannot be
+overridden. See also the [`set_vm_metadata` CPI method](set-vm-metadata.md)
+for more info about those default tags.
+
+For disks, the `director`, `deployment`, `instance_group`, `instance_id`,
+`instance_index` and `attached_at` are default Bosh tags that cannot be
+overridden. See  the [`set_disk_metadata` CPI method](set-disk-metadata.md)
+for more info about those.
+
 Example:
 
 ```yaml

--- a/content/manifest-v2.md
+++ b/content/manifest-v2.md
@@ -335,7 +335,7 @@ See [CLI Variable Interpolation](cli-int.md) for more details about variables.
 Both VMs and disks get tagged by these custom tags.
 
 For VMs, the `director`, `deployment`, `instance_group`, `job`, `id`, `name`,
-`index` and `created_at` default tags enforced by Bosh, that cannot be
+`index` and `created_at` are default tags enforced by Bosh that cannot be
 overridden. See also the [`set_vm_metadata` CPI method](set-vm-metadata.md)
 for more info about those default tags.
 

--- a/content/runtime-config.md
+++ b/content/runtime-config.md
@@ -237,7 +237,7 @@ In pseudocode:
 Both VMs and disks get tagged by these custom tags.
 
 For VMs, the `director`, `deployment`, `instance_group`, `job`, `id`, `name`,
-`index` and `created_at` default tags enforced by Bosh, that cannot be
+`index` and `created_at` are default tags enforced by Bosh that cannot be
 overridden. See also the [`set_vm_metadata` CPI method](set-vm-metadata.md)
 for more info about those default tags.
 

--- a/content/runtime-config.md
+++ b/content/runtime-config.md
@@ -234,6 +234,18 @@ In pseudocode:
 
 **tags** [Hash, optional]: Specifies key value pairs to be sent to the CPI for VM tagging. Combined with deployment level tags during the deploy. Available in bosh-release v260+.
 
+Both VMs and disks get tagged by these custom tags.
+
+For VMs, the `director`, `deployment`, `instance_group`, `job`, `id`, `name`,
+`index` and `created_at` default tags enforced by Bosh, that cannot be
+overridden. See also the [`set_vm_metadata` CPI method](set-vm-metadata.md)
+for more info about those default tags.
+
+For disks, the `director`, `deployment`, `instance_group`, `instance_id`,
+`instance_index` and `attached_at` are default Bosh tags that cannot be
+overridden. See  the [`set_disk_metadata` CPI method](set-disk-metadata.md)
+for more info about those.
+
 Example:
 
 ```yaml


### PR DESCRIPTION
Hi Bosh fellows!

Following [this answer](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/issues/348#issuecomment-1353460331) in a vSphere CPI issue, I’ve decided to improve the Bosh documentation about VM and disk tagging.

In this PR, I’m documenting default VM tags and default disk tags. I let you guys have a look and hopefully check for any typos, mistakes or anything, before we merge this.

Thanks!