### PR TITLE
Documents '--system' and '--all-logs' flags

### DIFF
--- a/content/cli-v2.md
+++ b/content/cli-v2.md
@@ -1106,8 +1106,10 @@ See [CPI config](cpi-config.md).
     - `--num=NUMBER` Last number of lines
     - `-q`, `--quiet` Suppresses printing of headers when multiple files are being examined
     - `--job=NAME` Limit to only specific jobs
-    - `--only=FILTERS` Filter logs in `/var/vcap/sys/log/` (comma-separated)
-    - `--agent` Include agent log
+    - `--only=FILTERS` Filter logs (comma-separated)
+    - `--agent` Include only agent logs
+    - `--system` Include only system logs
+    - `--all-logs` Include all logs (agent, system, and job logs)
     - `--gw-disable` Disable usage of gateway connection [$BOSH_GW_DISABLE]
     - `--gw-user=USER` Username for gateway connection [$BOSH_GW_USER]
     - `--gw-host=HOST` Host for gateway connection [$BOSH_GW_HOST]
@@ -1122,10 +1124,19 @@ See [CPI config](cpi-config.md).
     ```shell
     bosh -e vbox -d cf logs diego-cell/209c42e5-3c1a-432a-8445-ab8d7c9f69b0
     bosh -e vbox -d cf logs diego-cell/209c42e5-3c1a-432a-8445-ab8d7c9f69b0 --job=rep --job=silkd
-    bosh -e vbox -d cf logs diego-cell/209c42e5-3c1a-432a-8445-ab8d7c9f69b0 --agent --only=*/*stderr.log
+    bosh -e vbox -d cf logs diego-cell/209c42e5-3c1a-432a-8445-ab8d7c9f69b0 --only='*/*stderr.log'
+    bosh -e vbox -d cf logs diego-cell/209c42e5-3c1a-432a-8445-ab8d7c9f69b0 --agent --only=current --only=sync-time.out
+    bosh -e vbox -d cf logs diego-cell/209c42e5-3c1a-432a-8445-ab8d7c9f69b0 --system --only=kern.log --only=syslog --only=auth.log
     bosh -e vbox -d cf logs -f
     bosh -e vbox -d cf logs -f --num=1000
+    bosh -e vbox -d cf logs -f --system --num=1000
     ```
+
+    !!! note
+        The `--system` and `--all-logs` flags require version `v7.2.0` or later of the BOSH CLI.
+
+    !!! note
+        Downloading `--system` or `--all-logs` logs requires special Agent support, and only works with Agents `v2.516.0` or newer. Following (with `--follow`) `--system` or `--all-logs` logs works with any Agent version.
 
 #### Events {: #events }
 

--- a/content/job-logs.md
+++ b/content/job-logs.md
@@ -71,6 +71,16 @@ sudo tail -f -n 200 /var/vcap/bosh/log/current
     Agent logs are only accessible to the root user.
 
 ---
+### System logs {: #system-logs }
+
+System logs contain configuration and runtime information from the Linux kernel and other process running on a VM that are not directly managed by the BOSH Agent. These logs are stored in `/var/log` and are occasionally of interest when debugging OS-level problems, or when determining whether or not a VM is undersized for its workload. `auditd` and `sar` logs are also stored here.
+
+If you're a Linux system adminstrator, you already know exactly the sorts of things that are in here -- BOSH does nothing particularly special with these logs.
+
+!!! note
+    System logs are generally only accessible to the root user.
+
+---
 ### Log rotation {: #log-rotation }
 
 BOSH log rotates release job logs with the [Logrotate](http://linuxconfig.org/logrotate) log file management utility. Logrotate is configured by the Agent to act on all `.log` files in the `/var/vcap/sys/log/`, `/var/vcap/sys/log/*/`, and `/var/vcap/sys/log/*/*/` directories.


### PR DESCRIPTION
This commit:
* Documents the '--system' and '--all-logs' flags for the 'logs' command.
* Documents the "new" 'system' log type. (This is just the contents of `/var/log`... it's not actually new. But we're allowing you to interact with it through the CLI for the first time, so it's a new CLI concept.)
* Notes that downloading 'system' logs requires using Agent v2.516.0 or later. I'm pretty sure that this is the right version.
* Updates the documentation for the logs-filtering '--only' flag. (The examples provided would have generated an empty log tarball. These new examples would actually generate a tarball that has files in it.)

_**Please look over this PR carefully.**_ I'm especially uncertain of the description I added of the "system" log type. I believe that it _should_ be documented, but I'm not at all certain that I've documented it well.
