### PR TITLE
Add Run dir tmpfs config docs

### DIFF
--- a/content/creds-tmpfs.md
+++ b/content/creds-tmpfs.md
@@ -106,3 +106,16 @@ instance_groups:
         settings:
           tmpfs: true
 ```
+#### Run Dir Configuration
+
+The `run` dir is always kept on an in-memory `tmpfs` with a default size of 16MB. Override the default size of the `tmpfs` mount by setting the following `env` properties in your deployment manifest.
+
+```yaml
+instance_groups:
+- name: zookeeper
+  ...
+  env:
+    bosh:
+      run_dir:
+        tmpfs_size: 128m
+```


### PR DESCRIPTION
Looking into the agent code for [run dir configuration](https://github.com/cloudfoundry/bosh-agent/blob/7be6aae979945918aff27cf134708238f073da04/platform/linux_platform.go#L850-L880) it is always placed on a `tmpfs` mount with a default size of 16MB. This is not reflected in our docs.

Fixes: #794