### PR TITLE
Consistenly link the documentation for the version of monit used with BOSH

### DIFF
--- a/content/create-release.md
+++ b/content/create-release.md
@@ -209,7 +209,7 @@ On a deployed release, a BOSH Agent runs on each job VM.
 BOSH communicates with the Agent, which in turn executes commands in the
 control script.
 The Agent does this using open source process monitoring software called
-[Monit](https://web.archive.org/web/20110816041503/https://mmonit.com/monit/documentation/monit.html).
+[Monit, version 5.2.5](https://web.archive.org/web/20110816041503/https://mmonit.co+m/monit/documentation/monit.html).
 
 The `monit` file for the `web_ui` job looks like this:
 

--- a/content/create-release.md
+++ b/content/create-release.md
@@ -209,7 +209,7 @@ On a deployed release, a BOSH Agent runs on each job VM.
 BOSH communicates with the Agent, which in turn executes commands in the
 control script.
 The Agent does this using open source process monitoring software called
-[Monit, version 5.2.5](https://web.archive.org/web/20110816041503/https://mmonit.co+m/monit/documentation/monit.html).
+[Monit, version 5.2.5](https://web.archive.org/web/20110816041503/https://mmonit.com/monit/documentation/monit.html).
 
 The `monit` file for the `web_ui` job looks like this:
 

--- a/content/create-release.md
+++ b/content/create-release.md
@@ -209,7 +209,7 @@ On a deployed release, a BOSH Agent runs on each job VM.
 BOSH communicates with the Agent, which in turn executes commands in the
 control script.
 The Agent does this using open source process monitoring software called
-[Monit](http://mmonit.com/monit/).
+[Monit](https://web.archive.org/web/20110816041503/https://mmonit.com/monit/documentation/monit.html).
 
 The `monit` file for the `web_ui` job looks like this:
 

--- a/content/monitoring.md
+++ b/content/monitoring.md
@@ -29,7 +29,7 @@ See [Automatic repair with Resurrector](resurrector.md) for details.
 ---
 ## Processes on VMs {: #process }
 
-Release jobs' process monitoring on each VM is done with the help of the [Monit](https://web.archive.org/web/20110816041503/https://mmonit.com/monit/documentation/monit.html). Monit continuously monitors presence of the configured release jobs' processes and restarts processes that are not found. Process restarts, failures, etc. are reported to the Agent which in turn reports them as alerts to the Health Monitor. Each Health Monitor plugin is given an opportunity to act on each alert.
+Release jobs' process monitoring on each VM is done with the help of [Monit, version 5.2.5](https://web.archive.org/web/20110816041503/https://mmonit.com/monit/documentation/monit.html). Monit continuously monitors presence of the configured release jobs' processes and restarts processes that are not found. Process restarts, failures, etc. are reported to the Agent which in turn reports them as alerts to the Health Monitor. Each Health Monitor plugin is given an opportunity to act on each alert.
 
 ---
 ## SSH Events {: #ssh }

--- a/content/monitoring.md
+++ b/content/monitoring.md
@@ -29,7 +29,7 @@ See [Automatic repair with Resurrector](resurrector.md) for details.
 ---
 ## Processes on VMs {: #process }
 
-Release jobs' process monitoring on each VM is done with the help of the [Monit](http://mmonit.com/monit/). Monit continuously monitors presence of the configured release jobs' processes and restarts processes that are not found. Process restarts, failures, etc. are reported to the Agent which in turn reports them as alerts to the Health Monitor. Each Health Monitor plugin is given an opportunity to act on each alert.
+Release jobs' process monitoring on each VM is done with the help of the [Monit](https://web.archive.org/web/20110816041503/https://mmonit.com/monit/documentation/monit.html). Monit continuously monitors presence of the configured release jobs' processes and restarts processes that are not found. Process restarts, failures, etc. are reported to the Agent which in turn reports them as alerts to the Health Monitor. Each Health Monitor plugin is given an opportunity to act on each alert.
 
 ---
 ## SSH Events {: #ssh }

--- a/content/vm-monit.md
+++ b/content/vm-monit.md
@@ -1,5 +1,4 @@
-The Agent on each deployment job VM is responsible for managing lifecycle of each enabled release job. It starts, monitors, restarts and stops release jobs' processes. These tasks are done with the help of the  [Monit](https://web.archive.org/web/20110816041503/https://mmonit.com/monit/documentation/monit.html). The Agent communicates with the Monit daemon through Monit HTTP APIs to add, remove, start, stop, monitor and unmonitor release jobs' processes.
-
+The Agent on each deployment job VM is responsible for managing lifecycle of each enabled release job. It starts, monitors, restarts and stops release jobs' processes. These tasks are done with the help of [Monit, version 5.2.5](https://web.archive.org/web/20110816041503/https://mmonit.com/monit/documentation/monit.html). The Agent communicates with the Monit daemon through Monit HTTP APIs to add, remove, start, stop, monitor and unmonitor release jobs' processes.
 ---
 ## Check Status {: #check-status }
 
@@ -110,4 +109,4 @@ Process 'nats'
 
 While debugging why certain process is failing it is usually useful to tell Monit to stop restarting the failing process. You can do so via `monit stop <process-name>` command. To start it back up use `monit start <process-name>` command.
 
-See [Monit manual](https://web.archive.org/web/20110816041503/https://mmonit.com/monit/documentation/monit.html) to learn more about Monit.
+See the [Archived Monit Documentation, for version 5.2.5](https://web.archive.org/web/20110816041503/https://mmonit.com/monit/documentation/monit.html) to learn more about Monit.

--- a/content/vm-monit.md
+++ b/content/vm-monit.md
@@ -1,4 +1,4 @@
-The Agent on each deployment job VM is responsible for managing lifecycle of each enabled release job. It starts, monitors, restarts and stops release jobs' processes. These tasks are done with the help of the  [Monit](http://mmonit.com/monit/). The Agent communicates with the Monit daemon through Monit HTTP APIs to add, remove, start, stop, monitor and unmonitor release jobs' processes.
+The Agent on each deployment job VM is responsible for managing lifecycle of each enabled release job. It starts, monitors, restarts and stops release jobs' processes. These tasks are done with the help of the  [Monit](https://web.archive.org/web/20110816041503/https://mmonit.com/monit/documentation/monit.html). The Agent communicates with the Monit daemon through Monit HTTP APIs to add, remove, start, stop, monitor and unmonitor release jobs' processes.
 
 ---
 ## Check Status {: #check-status }
@@ -110,4 +110,4 @@ Process 'nats'
 
 While debugging why certain process is failing it is usually useful to tell Monit to stop restarting the failing process. You can do so via `monit stop <process-name>` command. To start it back up use `monit start <process-name>` command.
 
-See [Monit manual](http://mmonit.com/monit/documentation/monit.html) to learn more about Monit.
+See [Monit manual](https://web.archive.org/web/20110816041503/https://mmonit.com/monit/documentation/monit.html) to learn more about Monit.


### PR DESCRIPTION
Use a snapshot archived by the Internet Archive's Wayback Machine as the
manual/documentation for Monit 5.2.5 can no longer be found on the
current website.
