### PR TITLE
Review and improve documentation about CLI-generated secrets

### DIFF
--- a/content/manifest-v2.md
+++ b/content/manifest-v2.md
@@ -334,6 +334,9 @@ variables:
 
 See [CLI Variable Interpolation](cli-int.md) for more details about variables.
 
+See [Variable Types](variable-types.md) for more details about CLI-supported
+generation for variables.
+
 ---
 ## Tags Block {: #tags }
 

--- a/content/variable-types.md
+++ b/content/variable-types.md
@@ -1,13 +1,36 @@
 (See [Variable Interpolation](cli-int.md) for introduction.)
 
-Currently CLI supports `certificate`, `password`, `rsa`, and `ssh` types whose supported generation options are detailed below. The Director (connected to a config server, typically credhub) may support additional types known by the config server. Please refer to [Credhub documentation](https://docs.cloudfoundry.org/credhub/credential-types.html#cred-types) for full details over credhub supported credentials types and their associated available generation options.
+Currently CLI supports `password`, `certificate`, `rsa`, and `ssh` types whose
+supported generation options are detailed below. The Director (connected to a
+config server, typically CredHub) may support additional types known by the
+config server.
+
+Please refer to [CredHub documentation][credhub_cred_types] for full details
+over CredHub supported credentials types and their associated available
+generation options.
+
+Please also refer to [variables block](manifest-v2/#variables) for useful
+options like `update_mode: converge` (knowing that when the Bosh CLI generates
+secrets in a local `--vars-store` file for `bosh create-env`, the
+`update_mode: converge` is not honored, though).
 
 Note that `<value>` indicates value obtained via `((var))` variable syntax.
+
+[credhub_cred_types]: https://docs.cloudfoundry.org/credhub/credential-types.html#cred-types
 
 ---
 ## Password {: #password }
 
-**<value>** [String]: Password value. When generated defaults to 20 chars (from `a-z0-9`).
+**<value>** [String]: Password value. A random string containing a fixed set
+of characters: lowercase letters (from `a` to `z`) and figures (from `0` to
+`9`).
+
+Generation options:
+
+* **length** [Number, optional]: The length of password to generate. Defaults
+  to `20` with the Bosh CLI (whereas the default length with CredHub [is `30`][credhub_gen_pwd_opts]).
+
+[credhub_gen_pwd_opts]: https://docs.cloudfoundry.org/api/credhub/version/2.9/#_generate_a_password_credential_request_fields
 
 ---
 ## Certificate {: #certificate }
@@ -17,15 +40,22 @@ Note that `<value>` indicates value obtained via `((var))` variable syntax.
 * **ca** [String]: Certificate's CA (PEM encoded).
 * **certificate** [String]: Certificate (PEM encoded).
 * **private_key** [String]: Private key (PEM encoded).
+  Since [Sept 8th, 2017][boshcli_priv_key_len], the Bosh CLI generates private
+  keys which are `3072` bits long, and doesn't provide any parameter for this,
+  whereas CredHub default [is 2048][credhub_gen_cert_opts].
+
+[boshcli_priv_key_len]: https://github.com/cloudfoundry/config-server/blob/0ef502116cccef2370f333d37abe9748df125e95/types/certificate_generator.go#L60
+[credhub_gen_cert_opts]: https://docs.cloudfoundry.org/api/credhub/version/2.9/#_generate_a_certificate_credential_request_fields
 
 Generation options:
 
-* **common_name** [String, required]: Common name. Example: `foo.com`.
-* **alternative_names** [Array, options]: Subject alternative names. Example: `["foo.com", "*.foo.com"]`.
+* **common_name** [String, required]: the Common Name (CN) used in the certificate subject. Example: `foo.com`.
+* **organization** [String, optional]: The organization name (O) used in the certificate subject. Defaults to `Cloud Foundry`.
+* **alternative_names** [Array, optional]: Subject alternative names. Example: `["foo.com", "*.foo.com"]`.
 * **is_ca** [Boolean, required]: Indicates whether this is a CA certificate (root or intermediate). Defaults to `false`.
 * **ca** [String, optional]: Specifies name of a CA certificate to use for making this certificate. Can be specified in conjuction with `is_ca` to produce an intermediate certificate.
-* **extended\_key\_usage** [Array, optional]: List of extended key usage. Possible values: `client_auth` and/or `server_auth`. Default: empty. Example: `[client_auth]`.
-* **duration** [Number, optional]: Duration in days of generated credential value. Default: 365. If a minimum duration is configured in CredHub and is greater than the user provided duration, the certificate will be generated using the minimum duration instead. 
+* **extended\_key\_usage** [Array, optional]: List of extended key usage. Possible values: `client_auth` and/or `server_auth`. Default: `[]` (empty list). Example: `["client_auth"]`.
+* **duration** [Number, optional]: Duration in days of generated credential value. Default: `365`. If a minimum duration is configured in CredHub and is greater than the user provided duration, the certificate will be generated using the minimum duration instead.
 
 Example:
 
@@ -80,7 +110,8 @@ variables:
 ---
 ## RSA {: #rsa }
 
-**<value>** [Hash]: RSA key. When generated defaults to 2048 bits.
+**<value>** [Hash]: RSA key. The Bosh CLI generates a private key which is
+`2048` bits long, and doesn't provide any parameter for this.
 
 * **private_key** [String]: Private key (PEM encoded).
 * **public_key** [String]: Public key (PEM encoded).
@@ -88,7 +119,8 @@ variables:
 ---
 ## SSH {: #ssh }
 
-**<value>** [Hash]: SSH key. When generated defaults to RSA 2048 bits.
+**<value>** [Hash]: SSH key. The Bosh CLI generates a RSA private key which is
+`2048` bits long, and doesn't provide any parameter for this.
 
 * **private_key** [String]: Private key (PEM encoded).
 * **public_key** [String]: Public key (OpenSSH format, "ssh-rsa ...").


### PR DESCRIPTION
Hi there,

In this PR, I’ve added some details about how the Bosh CLI generates secrets, mentioning the inconsistent defaults with CredHub whenever they differ.

I let you review and provide feedback if any, thanks!