### PR TITLE
Detail the contract for log files, plus various other improvements

### DIFF
--- a/content/instance-metadata.md
+++ b/content/instance-metadata.md
@@ -9,7 +9,17 @@ Use [`spec` variable](jobs.md#properties-spec) in ERB templates to get access to
 
 ## Via filesystem {: #fs }
 
-Accessing information over filesystem might be useful when building core libraries so that explicit configuration is not required. Each VM has a `/var/vcap/instance` directory that contains following files:
+Accessing the Bosh structural information over filesystem might be useful when building core libraries so that explicit configuration is not required.
+
+Each VM has a `/var/vcap/instance` directory that contains following files:
+
+* `deployment`: Name of the deployment that the instance belongs to.
+* `name`: Name of the _instance group_ that the instance belongs to.
+* `az`: Name of the availability zone that the instance is placed in.
+* `index`: Human-friendly ordinal for the instance within its group.
+* `id`: Immutable UUID for the instance.
+
+Example:
 
 ```shell
 ls -la /var/vcap/instance/
@@ -25,7 +35,7 @@ drwxr-xr-x 11 root root 4096 Mar 17 00:16 ..
 -rw-r--r--  1 root root    3 Mar 17 00:07 name
 ```
 
-Example values:
+Example contents:
 
 - AZ: `z1`
 - Deployment: `redis`

--- a/content/job-logs.md
+++ b/content/job-logs.md
@@ -83,9 +83,15 @@ If you're a Linux system adminstrator, you already know exactly the sorts of thi
 ---
 ### Log rotation {: #log-rotation }
 
-BOSH log rotates release job logs with the [Logrotate](http://linuxconfig.org/logrotate) log file management utility. Logrotate is configured by the Agent to act on all `.log` files in the `/var/vcap/sys/log/`, `/var/vcap/sys/log/*/`, and `/var/vcap/sys/log/*/*/` directories.
+BOSH rotates release job logs with the [Logrotate][logrotate] log file management utility. Logrotate is configured by the Agent to act on all `.log` files in the `/var/vcap/sys/log/`, `/var/vcap/sys/log/*/`, and `/var/vcap/sys/log/*/*/` directories.
 
-Logs are rotated every 15 minutes (see [agent's `etcLogrotateDTemplate` configuration](https://github.com/cloudfoundry/bosh-agent/blob/master/platform/linux_platform.go#L525) for detailed settings).
+See also the [“Global Configuration” section](vm-config.md#global) for more
+details on the contract for log files.
+
+Logs are rotated every 15 minutes (see [agent's `etcLogrotateDTemplate` configuration][etcLogrotateDTemplate] for detailed settings).
+
+[logrotate]: http://linuxconfig.org/logrotate
+[etcLogrotateDTemplate]: https://github.com/cloudfoundry/bosh-agent/blob/f0b849f/platform/linux_platform.go#L594
 
 ---
 ### Syslog configuration {: #syslog-conf }

--- a/content/job-logs.md
+++ b/content/job-logs.md
@@ -77,7 +77,7 @@ System logs contain configuration and runtime information from the Linux kernel 
 
 If you're a Linux system adminstrator, you already know exactly the sorts of things that are in here -- BOSH does nothing particularly special with these logs.
 
-!!! note
+!!! Note
     System logs are generally only accessible to the root user.
 
 ---

--- a/content/vm-config.md
+++ b/content/vm-config.md
@@ -76,7 +76,7 @@ It's discouraged to modify or rely on the contents of this directory.
   with NATS client certificates, that are short-lived at bootstrap, and then
   replaced by the definitive client certificates, using `update_settings`.
 
-* `/var/vcap/bosh/spec.json`: Instance settings used by the Agent to configure release jobs and packages for the VM. This file also includes structural info about the instance, like the deployment name (`deplpyment`), the instance group (`name`), the human-friendly instance ordinal (`index`), and the immutable instance UUID (`id`).
+* `/var/vcap/bosh/spec.json`: Instance settings used by the Agent to configure release jobs and packages for the VM. This file also includes structural info about the instance, like the deployment name (`deplpyment`), the instance group (`name`), the human-friendly instance ordinal (`index`), and the immutable instance UUID (`id`). These structural info are also put in the `/var/vcap/instance` directory for easier access, see [Instance Metadata on Filesystem](instance-metadata.md#fs) for more details.
 
 * `/var/vcap/bosh/log/current`: Current Agent log. Agent's logs are logrotated and archives are kept in `/var/vcap/bosh/log/` directory.
 

--- a/content/vm-config.md
+++ b/content/vm-config.md
@@ -9,7 +9,22 @@ BOSH tries to encourage release authors to follow conventions listed below, so i
 
 * `vcap` user: Pre-configured user that comes with the stemcells. Release jobs may run processes under that user. The default password will be random.
 
-* `/etc/logrotate.d/vcap`: Logrotate configuration for `/var/vcap/sys/log/` sub-directories managed by the Agent.
+* `/etc/logrotate.d/vcap`: Logrotate configuration for `/var/vcap/sys/log/` sub-directories. See the [“Log rotation” section](job-logs.md#log-rotation) for more details on rotation of log files.
+
+    The contract with release authors, for the log files produced by jobs, is
+    the following:
+
+    1. Log files _SHOULD_ be place inside the `/var/vcap/sys/log/<job-name>/`
+       directory.
+    2. Log files _MAY_ be placed one level deeper in a
+       `/var/vcap/sys/log/<job-name>/<process-name>/` directory, this is
+       supported.
+    3. Log files _MAY_ be placed directly in `/var/vcap/sys/log/` but it's
+       discouraged to do so.
+    4. Log files _MUST NOT_ be placed anywhere else that these locations.
+    5. Filenames for log files _MUST_ end with `.log`.
+    6. Filenames _MAY_ start with a dot (`.`) if release authors are forced to do
+       so, but it's not recommended.
 
 ---
 ## Release Job and Package Directories {: #jobs-and-packages }

--- a/content/vm-config.md
+++ b/content/vm-config.md
@@ -1,6 +1,6 @@
-This topic describes important file system locations, configurations and other settings that are true for all VMs managed by BOSH.
+This topic describes important file system locations, configurations and other settings that are true for all the VMs managed by Bosh, also called the “Bosh instances”.
 
-BOSH tries to encourage release authors to follow conventions listed below, so if you find inconsistencies or improper usage please report such problems to appropriate release authors.
+BOSH tries to encourage release authors to follow the conventions listed below, so if you find inconsistencies or improper usage please report such problems to appropriate release authors.
 
 ---
 ## Global Configuration {: #global }
@@ -9,7 +9,14 @@ BOSH tries to encourage release authors to follow conventions listed below, so i
 
 * `vcap` user: Pre-configured user that comes with the stemcells. Release jobs may run processes under that user. The default password will be random.
 
-* `/etc/logrotate.d/vcap`: Logrotate configuration for `/var/vcap/sys/log/` sub-directories. See the [“Log rotation” section](job-logs.md#log-rotation) for more details on rotation of log files.
+!!! Note
+    BPM enforces that convention and runs processes with the `vcap` user by
+    default. Release authors should not run processes as `root` user, but
+    instead use the `capabilities` array, in BPM configuration. See the
+    [process Schema](https://bosh.io/docs/bpm/config/#process-schema) section
+    for more details.
+
+* `/etc/logrotate.d/vcap`: Logrotate configuration for `/var/vcap/sys/log/` sub-directories. See the [“Log rotation” section](job-logs.md#log-rotation)     for more details on rotation of log files.
 
     The contract with release authors, for the log files produced by jobs, is
     the following:
@@ -29,17 +36,17 @@ BOSH tries to encourage release authors to follow conventions listed below, so i
 ---
 ## Release Job and Package Directories {: #jobs-and-packages }
 
-* `/var/vcap/`: VCAP [1] directory contains majority of the configuration settings and associated assets when VM deployment job instance is assigned to the VM.
+* `/var/vcap/`: VCAP<sup>[1]</sup> directory contains majority of the configuration settings and associated assets for the Bosh instance.
 
-* `/var/vcap/packages/`: Contains enabled release packages for the assigned deployment job. The Agent is responsible for managing which packages are enabled or disabled on the VM.
+* `/var/vcap/packages/`: Contains enabled release packages for the instance. The Agent is responsible for managing which packages are enabled or disabled on the VM.
 
-* `/var/vcap/jobs/`: Contains evaluated release jobs for the assigned deployment job. The Agent is responsible for managing which jobs are enabled or disabled on the VM.
+* `/var/vcap/jobs/`: Contains evaluated release jobs for the instance. The Agent is responsible for managing which jobs are enabled or disabled on the VM.
 
-    - `/var/vcap/jobs/<name>/bin/`: Conventional location for the release job to keep wrapper executables. ctl script(s) invoked by Monit are placed here (e.g. `/var/vcap/jobs/redis-server/bin/ctl`).
+    - `/var/vcap/jobs/<job-name>/bin/`: Conventional location where Bosh renders the templates for wrapper scripts and [hook scripts](job-lifecycle.md).
 
-    - `/var/vcap/jobs/<name>/config/`: Conventional location for the release job configuration files (e.g. `/var/vcap/jobs/redis-server/config/redis.conf`).
+    - `/var/vcap/jobs/<job-name>/config/`: Conventional location for the job configuration files, like BPM config (in `/var/vcap/jobs/redis-server/config/bpm.yml`, responsible for starting exacutables). and other rendered config files (e.g. `/var/vcap/jobs/redis-server/config/redis.conf`).
 
-    - `/var/vcap/jobs/<name>/monit`: Final monit file for that release job.
+    - `/var/vcap/jobs/<job-name>/monit`: The rendered monit file for that release job. (All such files are then gathered by the Bosh Agent in `/var/vcap/monit/job`, where the actual monit configuration relies, see below.)
 
 ---
 ## Storage Directories {: #storage }
@@ -63,7 +70,13 @@ It's discouraged to modify or rely on the contents of this directory.
 
 * `/var/vcap/bosh/settings.json`: Local copy of the bootstrap settings used by the Agent to configure network, system properties for the VM. They are refreshed every time Agent is restarted.
 
-* `/var/vcap/bosh/spec.json`: Deployment job settings used by the Agent to configure release jobs and packages for the VM. This file also includes name and index for the deployment job associated with this VM.
+* `/var/vcap/bosh/update_settings.json`: The updated settings, as pushed by
+  the last `update_settings` RPC message sent through NATS to the Bosh Agent.
+  These settings may differ from the bootstrap `settings.json`, especially
+  with NATS client certificates, that are short-lived at bootstrap, and then
+  replaced by the definitive client certificates, using `update_settings`.
+
+* `/var/vcap/bosh/spec.json`: Instance settings used by the Agent to configure release jobs and packages for the VM. This file also includes structural info about the instance, like the deployment name (`deplpyment`), the instance group (`name`), the human-friendly instance ordinal (`index`), and the immutable instance UUID (`id`).
 
 * `/var/vcap/bosh/log/current`: Current Agent log. Agent's logs are logrotated and archives are kept in `/var/vcap/bosh/log/` directory.
 
@@ -78,4 +91,4 @@ It's discouraged to modify or rely on the contents of this directory.
 
 * `/var/vcap/monit/monit.log`: Monit activity log. Includes information about starts, stops, restarts, etc. of release job processes monitored by Monit.
 
-[1] VCAP stands for VMware Cloud Application Platform.
+<sup>[1]</sup> “VCAP” stands for “VMware Cloud Application Platform”.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,7 +155,7 @@ pages:
     - Configuring NTP: ntp-config.md
     - Virtual Machines:
       - Structure of a VM: vm-struct.md
-      - Configuration Locations: vm-config.md
+      - Filesystem Locations: vm-config.md
       - Using Logs: job-logs.md
       - Instance Metadata: instance-metadata.md
   - Development:


### PR DESCRIPTION
Hi Bosh mates!

In the context of cloudfoundry/syslog-release#71, I’ve reviewed these pieces of docs, with these goals:
- Detail the contract for log files
- Replace Bosh v1 terms by proper Bosh v2 terms, to avoid confusion
- Detail the contents of `/var/vcap/instance`
- Properly link the related docs

Cheers