### PR TITLE
Review template rendering, and release authoring-related docs

### DIFF
--- a/content/dns.md
+++ b/content/dns.md
@@ -353,7 +353,13 @@ As of bosh-release v263 opting into DNS addresses in links must be done explicit
 
 You can control type of addresses returned at three different levels:
 
-- for the entire Director via Director job configuration [`director.local_dns.use_dns_addresses` property](https://bosh.io/jobs/director?source=github.com/cloudfoundry/bosh#p=director.local_dns.use_dns_addresses) that if enabled affects all deployments by default. We are planning to eventually change this configuration to true by default.
+- for the entire Director, via the `director` job configuration [`director.local_dns.use_dns_addresses` property](https://bosh.io/jobs/director?source=github.com/cloudfoundry/bosh#p=director.local_dns.use_dns_addresses) that affects all deployments when enabled. We are planning to eventually change this configuration to `true` by default.
+
+  Please note that although the default for this setting is `false` in the
+  Bosh Release for the Bosh Director, the “bosh-deployment” in turn,
+  [enables it by default](https://github.com/cloudfoundry/bosh-deployment/blob/1128dd7/bosh.yml#L82).
+  So, in fact most Bosh installations already have the `use_dns_addresses`
+  enabled.
 
 - for a specific deployment via [`features.use_dns_addresses` deployment manifest property](manifest-v2.md#features) that if enabled affects links within this deployment
 

--- a/content/dns.md
+++ b/content/dns.md
@@ -223,6 +223,17 @@ aliases:
   initial_health_check: asynchronous/synchronous
 ```
 
+!!! Note
+    When using `placeholder_type: uuid` or `placeholder_type: index`, the
+    value for `health_filter` has some importance. Indeed, when the instance
+    behind the alias is unhealthy, the default `health_filter: smart` will
+    resolve the alias to no address at all, or if you prefer, an empty list of
+    IP addresses. Depending on your use-case, you might expect an `index`- or
+    `uuid`-based alias to always return the IP address of the designated
+    instance, and let clients load-balance the traffic to healthy instances
+    with their own mechanisms. With such use-case, that expects one instance
+    to always be resolved, then opt for `health_filter: all`.
+
 ###### Parameters in Detail
 
 **domain** [String] (*required*) 

--- a/content/jobs.md
+++ b/content/jobs.md
@@ -360,6 +360,29 @@ information, networking setup, and instance configuration.
       to `spec.<network-name>.ip`, `spec.<network-name>.netmask` and
       `spec.<network-name>.gateway`.
 
+Fetching the name of the network that has the default gateway is particularily
+complex, as the `spec` object is not a Ruby Hash, but an OpenStruct.
+
+As a consequence, one cannot use the `.keys` method for listing the network
+names. But Bosh provides a special helper method `.methods(false)` on the
+OpenStruct that does the trick.
+
+So, one can use the expression `spec.networks.methods(false)` in order to list
+the network names. Based on this, use the following code snippet in your ERB
+templates, whenever you need the name of the “default” network (i.e. the one
+use for the default gateway, at least).
+
+```ruby
+network = spec.networks.methods(false).find { |net_name|
+              # Pick the network that is used for the default gateway
+              default_for = spec.networks[net_name].default
+              !default_for.nil? && default_for.include?("gateway")
+          }
+```
+
+Obtaining the default network is absolutely necessary when building default
+Bosh DNS FQDNs, which include that network name.
+
 ##### Instance configuration
 
 - `spec.persistent_disk`: is `0` if no persistent disk is mounted to the

--- a/content/jobs.md
+++ b/content/jobs.md
@@ -58,13 +58,13 @@ Schema:
     * **name** [String, required]: Name of the link to find.
     * **type** [String, required]: Type of the link to be found. This is an
       arbitrary naming. Usual and conventional types are `address` when the
-      link goal is to expose a Bosh DNS name atht allows accessing the
+      link goal is to expose a Bosh DNS name that allows accessing the
       instances of the group. Usually typed by technology, like `mysql`,
       `postgres`, `cassandra`, etc. Anything that makes sense is relevant and
       matters.
     * **optional** [Boolean, optional]: Whether finding an matching link is
       optional (when `true`) or mandatory (when `false`. Default is `false`,
-      so optinal links must be explicitly declared as such.
+      so optional links must be explicitly declared as such.
 * **provides** [Array, optional]: Links that are exposed to other jobs for
   rendering their ERB templates.
     * **name** [String, required]: Name of the exposed link.
@@ -87,7 +87,7 @@ Schema:
           Default is `nil`.
 
 !!! Note
-    Within a peoperty definition, `default` is used by the Director, and
+    Within a property definition, `default` is used by the Director, and
     `description`, `default` and `example` are displayed by the
     [release index](/releases). In turns, other keys like `type` are used only
     for convenience, like Concourse does `env` keys in the
@@ -101,14 +101,14 @@ Schema:
 
 Release authors can define zero or more templates for each job, but typically
 you need at least a template for the BPM config file, that is expected to
-renderd to the `config/bpm.yml` location.
+rendered to the `config/bpm.yml` location.
 
 ### Favor Bosh Process Manager (BPM) over Monit {: #monit }
 
 Monit is a component of the Bosh architecture that was introduced in the early
 days, and has always been deemed to get rid of soon. But history has shown
-over the years that transitionning away from Monit is complex-engough for
-being hold back since then.
+over the years that transitioning away from Monit is complex-enough for being
+hold back since then.
 
 As a consequence, Release authors should avoid at all costs relying on fancy
 Monit features. Instead, they should use a very simple and standard `monit`

--- a/content/jobs.md
+++ b/content/jobs.md
@@ -251,13 +251,13 @@ Advanced usage:
       in which case the block is evaluated only if _all_ the properties are
       defined.
 
-After the `end` of an `if_p` block, the `.else ... end` and
-`.else_if_p("other.property") ... end` syntaxes are supported.
+After the `end` of an `if_p` block, the `.else do ... end` and
+`.else_if_p("other.property") do ... end` syntaxes are supported.
 
-- `<% if_p("some.property") do |prop| %>...<% end.else %>...<% end %>` -
+- `<% if_p("some.property") do |prop| %>...<% end.else do %>...<% end %>` -
   Evaluates first block if `some.property` has been provoded (or has a default
   in job spec), otherwise evaluates the second block.
-- `<% if_p("some.property") do |prop| %>...<% end.else_if_p("other.property") |prop2| %>...<% end.else %>...<% end %>` -
+- `<% if_p("some.property") do |prop| %>...<% end.else_if_p("other.property") do |prop2| %>...<% end.else do %>...<% end %>` -
   Evaluates first block if `some.property` has been provided (or has a default
   in job spec), otherwise evaluates the second block if `other.property` has
   been provided (or has a default in job spec), otherwise evaluates the third
@@ -270,9 +270,9 @@ methods, and `.else_if_p()` or `.else` blocks.
   If `remote.prop` is defined in the job that is resolved through navigating
   the `relation-name` link, then the block is evaluated with the value in the
   local variable `prop`.
-- `<%= link("relation-name").if_p("remote.prop") do |prop| %>...<% end.else %>...<% end %>` -
-  Same as above with an `.else ... end` block.
-- `<%= link("relation-name").if_p("remote.prop") do |prop| %>...<% end.else_if_p("other.prop2") |prop2| %>...<% end.else %>...<% end %>` -
+- `<%= link("relation-name").if_p("remote.prop") do |prop| %>...<% end.else do %>...<% end %>` -
+  Same as above with an `.else do ... end` block.
+- `<%= link("relation-name").if_p("remote.prop") do |prop| %>...<% end.else_if_p("other.prop2") do |prop2| %>...<% end.else do %>...<% end %>` -
   Same as above with an `.else_if_p` block that evaluates only when
   `other.prop2` is defined through navigating the `relation-name` link.
 

--- a/content/jobs.md
+++ b/content/jobs.md
@@ -314,6 +314,13 @@ information, networking setup, and instance configuration.
     assume there is necessarily an instance with index `0`, and use
     `spec.bootstrap` instead.
 
+!!! Caveat
+    From within an ERB template, there is no programatic way to know the name
+    of the job that the template is defined in. Thus release authors are
+    forced to hardcode the job name in ERB templates that need it. Due to this
+    limitation, there is unfortunately no way to write ERB templates that are
+    agnostic of the job name they belong to.
+
 ##### Networking setup
 
 - `spec.address`: Default network address for the instance. This can be an


### PR DESCRIPTION
Hello Bosh mates,

This is a big PR after a large review of several pieces of docs related to release development. As a release author and as a trainer _(facing the trainees legitimate “surprise” when reading the Bosh docs)_, I wanted to complete and update these for _years_, so I’m glad I can contribute something today.

Individual commits are breaking the changes into smaller consistent chunks. This might ease the review.

I’ve went quite far in documenting the  `spec` object in the evaluation context for ERB templates. In fact, many exposed properties should not be there at all. We can discuss which ones, and I can submit a PR for that refactoring in bosh core.

I’ve also added a “caveat” about the obviously missing `spec.job_name` property, that would be very useful for release authors, even though not strictly necessary. Indeed, that would allow writing ERB snippets that can just be used with pure copy/paste, no editing, and that would be cool. Being cool _does_ matter.

Cheers