### PR TITLE
Resize Disk support docs for AWS & GCP

### DIFF
--- a/content/cpi-api-v2-method/resize-disk.md
+++ b/content/cpi-api-v2-method/resize-disk.md
@@ -23,6 +23,7 @@ No return value
 ### Implementations
 
  * [cloudfoundry/bosh-openstack-cpi-release](https://github.com/cloudfoundry/bosh-openstack-cpi-release/blob/88e1c6d402b3c4ce23ad39ebdf5ab5fc93790127/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb#L701)
+ * [cloudfoundry/bosh-aws-cpi-release](https://github.com/cloudfoundry/bosh-aws-cpi-release/blob/7906dc66c61d4667ad74beeda3e5627f997ad740/src/bosh_aws_cpi/lib/cloud/aws/cloud_core.rb#L165)
 
 
 ## Related

--- a/content/cpi-api-v2-method/resize-disk.md
+++ b/content/cpi-api-v2-method/resize-disk.md
@@ -24,6 +24,7 @@ No return value
 
  * [cloudfoundry/bosh-openstack-cpi-release](https://github.com/cloudfoundry/bosh-openstack-cpi-release/blob/88e1c6d402b3c4ce23ad39ebdf5ab5fc93790127/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb#L701)
  * [cloudfoundry/bosh-aws-cpi-release](https://github.com/cloudfoundry/bosh-aws-cpi-release/blob/7906dc66c61d4667ad74beeda3e5627f997ad740/src/bosh_aws_cpi/lib/cloud/aws/cloud_core.rb#L165)
+ * [cloudfoundry/bosh-google-cpi-release](https://github.com/cloudfoundry/bosh-google-cpi-release/blob/f2d17fe164daa690acb37d5758b689a8cbc32852/src/bosh-google-cpi/action/concrete_factory.go#L180)
 
 
 ## Related


### PR DESCRIPTION
It seems like the docs were never updated when these properties were enabled for both AWS & GCP. https://github.com/cloudfoundry/bosh-agent/pull/244