### PR TITLE
Add Cpi config in the reference TOC

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -169,6 +169,7 @@ pages:
 - Reference:
   - Terminology: terminology.md
   - Deployment Config: manifest-v2.md
+  - Cpi Config: cpi-config.md
   - Director Cloud Config:
     - Usage: cloud-config.md
     - Availability Zones: azs.md


### PR DESCRIPTION
This makes the reference TOC now include all config files: cloud-config, runtime-config and generic config