### PR TITLE
Highlight overriding capabilities for vsphere cpi, and illustrate it for storage placement

### DIFF
--- a/content/vsphere-cpi.md
+++ b/content/vsphere-cpi.md
@@ -1,4 +1,4 @@
-This topic describes cloud properties for different resources created by the vSphere CPI.
+This topic describes cloud properties supported for different resources created by the vSphere CPI. The cloud properties can be specified at the different levels supported in the [Cloud Config](cloud-config.md). Typically, define defaults at the global level and override them at the [`azs`](cloud-config.md#azs), [`networks`](cloud-config.md#networks), [`vm_types`](cloud-config.md#vm-types) [`vm_extension`](cloud-config.md#vm-extensions) or [`disk_types`](#disk-types) levels. 
 
 ## AZs {: #azs }
 
@@ -167,6 +167,16 @@ vm_types:
   name: vm_type_name
 ```
 
+Example of overriding the default target datastore used by ephemeral storage through a [vm_extension](manifest-v2.md#instance-groups) specified in the deployment manifest:
+
+```yaml
+vm_extensions:
+  - name: ephemeral-to-ds2
+    cloud_properties:
+      datastores:
+        - 'prod-ds-2'
+  ```
+
 Example of attaching a PCI card to a VM:
 
 ```yaml
@@ -225,13 +235,19 @@ Example of disk with type eagerZeroedThick:
     type: eagerZeroedThick
 ```
 
-Example of disk stored in specific datastores:
+Example of persistent disk stored in specific datastores:
 
 ```yaml
 - name: default
   disk_size: 10_240
   cloud_properties:
-    datastores: ['prod-ds-1', 'prod-ds-2', {clusters: [vcpi-sp1: {}  , vcpi-sp2: {}]}]
+    datastores:
+      # datastores to be used as candidates in the vm placement algorithm (see #vm-placement)
+      - 'prod-ds-1'
+      - 'prod-ds-2'
+      - clusters: # storage clusters used if SRDS is turned on
+          - vcpi-sp1: {}
+          - vcpi-sp2: {}
 ```
 
 ---

--- a/content/vsphere-cpi.md
+++ b/content/vsphere-cpi.md
@@ -538,9 +538,10 @@ The vSphere CPI only supports a single datacenter and errors if more than one is
 The current code will not work with a datacenter inside a folder.
 
 ### Storage Policy
+
 The order of precedence for policy and datastore specified for selecting ephemeral datastores is (in order they are written from
-top to bottom , first being most preffered.)
- - Storage policy is set in vm-type
- - Datastores in vm-type
- - Storage policy in Global config
- - Datastore pattern in global config
+top to bottom, first being most preferred):
+- Storage policy is set in vm-type
+- Datastores in vm-type
+- Storage policy in Global config
+- Datastore pattern in global config

--- a/content/vsphere-cpi.md
+++ b/content/vsphere-cpi.md
@@ -212,8 +212,8 @@ vm_extensions:
 
 Schema for `cloud_properties` section:
 
-* **type** [String, optional]: Type of the
-  [disk](http://pubs.vmware.com/vi-sdk/visdk250/ReferenceGuide/vim.VirtualDiskManager.VirtualDiskType.html):
+* **type** [String, optional]: 
+  [Virtual disk type](http://pubs.vmware.com/vi-sdk/visdk250/ReferenceGuide/vim.VirtualDiskManager.VirtualDiskType.html) used for persistent disks:
   `thick`, `thin`, `preallocated`, `eagerZeroedThick`. Defaults to
   `preallocated`. Available in v12. Overrides the global `default_disk_type`.
 

--- a/content/vsphere-migrate-datastores.md
+++ b/content/vsphere-migrate-datastores.md
@@ -5,7 +5,7 @@ This topic describes how to migrate VMs and persistent disks from one datastore 
 
 1. Attach new datastore(s) to the hosts where the VMs are running while keeping the old datastore(s) attached to the same hosts.
 
-1. Change deployment manifest for the Director to configure vSphere CPI to reference new datastore(s).
+1. Change deployment manifest for the Director to configure vSphere CPI to reference new datastore(s). 
 
     ```json
     properties:
@@ -30,3 +30,5 @@ This topic describes how to migrate VMs and persistent disks from one datastore 
 1. For each one of the deployments managed by the Director (visible via [`bosh deployments`](sysadmin-commands.md#deployment)), run [`bosh deploy --recreate`](sysadmin-commands.md#deployment) so that VMs are recreated and persistent disks are reattached.
 
 1. Verify that the persistent disks and VMs were moved to new datastore(s) and there are no remaining disks in the old datastore(s).
+
+Alternatively, you may modify the `cloud-config`  at the global level, az level, or disk-type level to specify the target datastore (without a director redeploy).


### PR DESCRIPTION
Explain the ability to override default vsphere configuration at the different levels and illustrate it for the storage placements with an example and the mention in the datastore migration guide.

See related slack exchange https://cloudfoundry.slack.com/archives/C02HPPYQ2/p1716918056721309?thread_ts=1716476234.575549&cid=C02HPPYQ2