### PR TITLE
Fix & detail ntp config in deployment manifest

### DIFF
--- a/content/manifest-v2.md
+++ b/content/manifest-v2.md
@@ -234,6 +234,7 @@ update:
         * **agent** [Hash, optional]:
             * **settings** [Hash, optional]:
               * **tmpfs** [Boolean, optional]: Mount agent settings on a [tmpfs](creds-tmpfs.md) directory. Default: `false`.
+        * **ntp** [Array, optional]: list of [ntp servers to synchronize to](ntp-config.md). Default: director-configured ntp servers. 
 
 Example:
 

--- a/content/ntp-config.md
+++ b/content/ntp-config.md
@@ -62,6 +62,11 @@ If you wanted to configure the NTP servers specifically for one
 instance group in a deployment you can do so using `env.bosh.ntp`
 property on that instance group in its deployment manifest.
 
+In order to completely disable NTP client configuration on one instance group, 
+specify an empty list `env.bosh.ntp=[]` on the instance group, and also configure
+an empty the default ntp list in the [bosh director default configuration of the cpi-release](https://github.com/cloudfoundry/bosh-deployment/blob/master/vsphere/cpi.yml), such
+as [vsphere-cpi](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/blob/34e66c47002c42e37970a02256f13be07a5d138f/jobs/vsphere_cpi/spec#L97-L101)
+
 ## Configuring NTP via CPI job properties is DEPRECATED
 
 If you configure NTP on an instance group that has CPI jobs, some CPIs will pick

--- a/content/ntp-config.md
+++ b/content/ntp-config.md
@@ -64,8 +64,8 @@ property on that instance group in its deployment manifest.
 
 In order to completely disable NTP client configuration on one instance group, 
 specify an empty list `env.bosh.ntp=[]` on the instance group, and also configure
-an empty the default ntp list in the [bosh director default configuration of the cpi-release](https://github.com/cloudfoundry/bosh-deployment/blob/master/vsphere/cpi.yml), such
-as [vsphere-cpi](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/blob/34e66c47002c42e37970a02256f13be07a5d138f/jobs/vsphere_cpi/spec#L97-L101)
+an empty ntp list in the [bosh director default configuration of the cpi-release](https://github.com/cloudfoundry/bosh-deployment/blob/master/vsphere/cpi.yml), for
+example [vsphere-cpi](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/blob/34e66c47002c42e37970a02256f13be07a5d138f/jobs/vsphere_cpi/spec#L97-L101)
 
 ## Configuring NTP via CPI job properties is DEPRECATED
 

--- a/content/ntp-config.md
+++ b/content/ntp-config.md
@@ -59,7 +59,7 @@ At this point you should know enough to configure NTP on your VMs. The rest of t
 ## It is also possible to configure the agent env on an instance-group basis
 
 If you wanted to configure the NTP servers specifically for one
-instance group in a deployment you can do so using `agent.env.bosh.ntp`
+instance group in a deployment you can do so using `env.bosh.ntp`
 property on that instance group in its deployment manifest.
 
 ## Configuring NTP via CPI job properties is DEPRECATED


### PR DESCRIPTION

## Fixed per instance ntp configuration 

Per instance ntp configuration require `env.bosh.ntp`

Bosh agent config in deployment manifest is loaded from `env.bosh` while bosh director manifest expects `agent.env.bosh.ntp`

Bosh agent config in deployment manifest is loaded from `env.bosh`, see https://github.com/cloudfoundry/docs-bosh/blob/880ea1a4de1cff6e9f95de85a595793ce52c76a2/content/manifest-v2.md?plain=1#L217-L223

Bosh agent expects `env.bosh.ntp` property, see https://github.com/cloudfoundry/bosh-agent/blob/d2bb9fc036e08df95e7a9c4af964793b04907f2a/settings/settings.go#L180-L185

## Detailed how to disable ntp configuration for an instance group.

Setting an empty `env.bosh.ntp` results into the cpi default ntp servers to be used such as `[0.pool.ntp.org, 1.pool.ntp.org]` for vsphere https://github.com/cloudfoundry/bosh-vsphere-cpi-release/blob/34e66c47002c42e37970a02256f13be07a5d138f/jobs/vsphere_cpi/spec#L97-L101

It is therefore necessary to also set a default empty list of ntp servers in the cpi-release configuration in the bosh director.

<details>
<summary>details of the chrony sources assignment as a result of the bosh agent ntp configuration</summary>

```
cat /etc/chrony/chrony.conf
[...]
# Use NTP sources found in /etc/chrony/sources.d.
sourcedir /etc/chrony/sources.d
[...]
# This directive enables kernel synchronisation (every 11 minutes) of the
# real-time clock. Note that it can’t be used along with the 'rtcfile' directive.
rtcsync


bosh/3cdf3468-8002-4c30-a420-e13123be5381:~# ls -al /etc/chrony/sources.d/
total 16
drwxr-xr-x 2 root root 4096 Jun  7 16:21 .
drwxr-xr-x 4 root root 4096 Jun  3 18:48 ..
-rw-r--r-- 1 root root  127 Jun  7 16:24 bosh.sources
-rw-r--r-- 1 root root  498 Feb  8  2022 README

osh/3cdf3468-8002-4c30-a420-e13123be5381:~# cat /etc/chrony/sources.d/bosh.sources 
# created by /var/vcap/bosh/bin/sync-time
server 0.pool.ntp.org iburst 
server 1.pool.ntp.org iburst

bosh/3cdf3468-8002-4c30-a420-e13123be5381:~# cat /var/vcap/bosh/bin/sync-time
#!/bin/bash

BOSH=/var/vcap/bosh
NTP_SERVER_FILE=$BOSH/etc/ntpserver
if [ ! -f $NTP_SERVER_FILE ]; then
  exit
fi

exec > $BOSH/log/sync-time.out
exec 2>&1

CHRONY_TIME_SOURCES_FILE=/etc/chrony/sources.d/bosh.sources

cat > $CHRONY_TIME_SOURCES_FILE <<EOF
# created by $0
EOF

for ip in $( cat $NTP_SERVER_FILE ); do
  echo "server $ip iburst" >> $CHRONY_TIME_SOURCES_FILE
done

chronyc reload sources
chronyc waitsync 10
```



</details>


Bosh agent disables ntp config when list of ntp servers is empty, and setting.ntp is empty
https://github.com/cloudfoundry/bosh-agent/blob/d2bb9fc036e08df95e7a9c4af964793b04907f2a/platform/linux_platform_test.go#L941-L961

List of ntp servers is empty when per-instance list is empty, and setting.ntp is empty
https://github.com/cloudfoundry/bosh-agent/blob/d2bb9fc036e08df95e7a9c4af964793b04907f2a/settings/settings_test.go#L1121-L1124

I did not yet find the code location in the director where the cpi-level ntp is sent as the agent setting.ntp (i.e. `/var/vcap/bosh/settings.json`

