### PR TITLE
fix formatting for configure blobstore for gcp section

### DIFF
--- a/content/director-configure-blobstore.md
+++ b/content/director-configure-blobstore.md
@@ -140,6 +140,7 @@ to store blobstore contents instead of the bucket default, specify `storage_clas
           json_key: |
             AGENT-SERVICE-ACCOUNT-BLOBSTORE-FILE
     ```
+   
 ---
 ## Azure Storage Account {: #azure-storage }
 


### PR DESCRIPTION
There is a weird section in the docs:

https://bosh.io/docs/director-configure-blobstore/#properties-blobstore-provider-gcs-credentials_source-static-json_key-director-blobstore-service-account-file-bucket_name-test-bosh-bucket-storage_class-regional-agent-blobstore-credentials_source-static-json_key-agent-service-account-blobstore-file

also the yaml snippet appears bigger than for the other ones. Maybe this space helps?