### PR TITLE
Update cli-int.md

### DIFF
--- a/content/cli-int.md
+++ b/content/cli-int.md
@@ -70,8 +70,8 @@ CLI allows to provide variable values via usage of one or more of the following 
 - `--vars-env=prefix` flag sets variable values found in prefixed environment variables (casing is important)
 
     ```shell
-    export FOO_s3_access_key_id=some-key
-    export FOO_s3_access_secret_key=some-secret
+    export FOO_access_key_id=some-key
+    export FOO_access_secret_key=some-secret
 
     bosh interpolate base.yml --vars-env FOO
     # s3_access_key_id: some-key


### PR DESCRIPTION
The environment variables exported should be prefixed with FOO and s3 prefix needs to be removed for the example to work as expected. There is a typo in the variable names.