### PR TITLE
Native Disk Update

### DIFF
--- a/content/aws.md
+++ b/content/aws.md
@@ -75,6 +75,7 @@ using the new key and migrate data onto the new disk.
 | --------------------------------- | ------------------------------ |
 | Multi-CPI                         | Supported, [v61][aws_cpi_v61]+ |
 | Native Disk Resize                | Supported, [v89][aws_cpi_v89]+ |
+| Native Disk Update                | Not Supported                  |
 | Generic VM Resource Configuration | Supported, [v56][aws_cpi_v56]+ |
 
 [aws_cpi_v61]: https://github.com/cloudfoundry/bosh-aws-cpi-release/releases/tag/v61

--- a/content/azure-cpi.md
+++ b/content/azure-cpi.md
@@ -326,20 +326,27 @@ instance_groups:
 ---
 ## Disk Types {: #disk-pools }
 
+* **name** [String, required]: Name of the disk type.
+* **disk_size** [Integer, required]: Size of the disk in MiB. On Azure the disk size must be greater than 1 * 1024 and less than the max disk size for [unmanaged](https://azure.microsoft.com/en-us/pricing/details/storage/unmanaged-disks/) or [managed](https://azure.microsoft.com/en-us/pricing/details/managed-disks/) disk. Please always use `N * 1024` as the size because Azure always uses GiB not MiB.
+
 Schema for `cloud_properties` section:
 
 * **caching** [String, optional]: Type of the disk caching. It can be either `None`, `ReadOnly` or `ReadWrite`. Default is `None`.
 * **storage\_account\_type** [String, optional]: Storage account type. Valid only when `use_managed_disks` is `true`. It can be either `Standard_LRS`, `Premium_LRS` or `PremiumV2_LRS`. You can click [**HERE**](http://azure.microsoft.com/en-us/pricing/details/storage/) to learn more about the type of Azure storage account. For `PremiumV2_LRS`, you have to set caching to `None` since `PremiumV2_LRS` does currently not support caching.
-* **disk_size** [Integer, required]: Size of the disk in MiB. On Azure the disk size must be greater than 1 * 1024 and less than the max disk size for [unmanaged](https://azure.microsoft.com/en-us/pricing/details/storage/unmanaged-disks/) or [managed](https://azure.microsoft.com/en-us/pricing/details/managed-disks/) disk. Please always use `N * 1024` as the size because Azure always uses GiB not MiB.
 * **iops** [Integer, optional]: IOPS of the disk. If you need more IOPS than the baseline offers, you can increase the IOPS of the disks. For more details, see [Premium SSD v2 performance](https://learn.microsoft.com/azure/virtual-machines/disks-types#premium-ssd-v2-performance). Only supported for `PremiumV2_LRS`
 * **mbps** [Integer, optional]: Throughput in MB/s of the disk. If you need more throughput than the baseline offers, you can increase the throughput of the disks. For more details, see [Premium SSD v2 performance](https://learn.microsoft.com/azure/virtual-machines/disks-types#premium-ssd-v2-performance). Only supported for `PremiumV2_LRS`
 
-Example of 10GB disk:
+Example of a 10GB Standard LRS disk:
+
 ```yaml
 disk_types:
 - name: default
   disk_size: 10_240
+  cloud_properties:
+    storage_account_type: Standard_LRS
 ```
+
+To modify the `cloud_properties` such as `storage_account_type`, `iops`, and `mbps` of a disk without the necessity to create a new one and transfer the data, you can utilize the [Native Disk Update Feature](./cpi-api-v2-method/update-disk.md).
 
 ---
 ## Global Configuration {: #global }

--- a/content/azure.md
+++ b/content/azure.md
@@ -87,7 +87,8 @@ transparently handles re-encryption of data.
 |              Feature              |             Support              |
 | --------------------------------- | -------------------------------- |
 | Multi-CPI                         | Not Supported                    |
-| Native Disk Resize                | Not Supported                    |
+| Native Disk Resize                | Supported, [v39][azure_cpi_v39]+ |
 | Generic VM Resource Configuration | Supported, [v33][azure_cpi_v33]+ |
 
 [azure_cpi_v33]: https://github.com/cloudfoundry/bosh-azure-cpi-release/releases/tag/v33
+[azure_cpi_v39]: https://github.com/cloudfoundry/bosh-azure-cpi-release/releases/tag/v39.0.0

--- a/content/azure.md
+++ b/content/azure.md
@@ -88,7 +88,9 @@ transparently handles re-encryption of data.
 | --------------------------------- | -------------------------------- |
 | Multi-CPI                         | Not Supported                    |
 | Native Disk Resize                | Supported, [v39][azure_cpi_v39]+ |
+| Native Disk Update                | Supported, [v50][azure_cpi_v50]+ |
 | Generic VM Resource Configuration | Supported, [v33][azure_cpi_v33]+ |
 
 [azure_cpi_v33]: https://github.com/cloudfoundry/bosh-azure-cpi-release/releases/tag/v33
 [azure_cpi_v39]: https://github.com/cloudfoundry/bosh-azure-cpi-release/releases/tag/v39.0.0
+[azure_cpi_v50]: https://github.com/cloudfoundry/bosh-azure-cpi-release/releases/tag/v50.0.0

--- a/content/cpi-api-rpc.md
+++ b/content/cpi-api-rpc.md
@@ -111,6 +111,7 @@ An example error response to [`create_vm`](cpi-api-v2-method/create-vm.md) might
     * [create_disk](cpi-api-v2-method/create-disk.md)
     * [delete_disk](cpi-api-v2-method/delete-disk.md)
     * [resize_disk](cpi-api-v2-method/resize-disk.md)
+    * [update_disk](cpi-api-v2-method/update-disk.md)
     * [has_disk](cpi-api-v2-method/has-disk.md)
     * [attach_disk](cpi-api-v2-method/attach-disk.md)
     * [detach_disk](cpi-api-v2-method/detach-disk.md)

--- a/content/cpi-api-v2-method/update-disk.md
+++ b/content/cpi-api-v2-method/update-disk.md
@@ -1,0 +1,36 @@
+# update_disk
+
+Update the disk using IaaS-native methods, ensuring it's detached from all VMs first. Activate this feature with the following director configuration:
+
+```yaml
+director:
+  enable_cpi_update_disk: true
+```
+
+Updating disk properties directly via the IaaS, such as changing the disk type or specific disk settings without needing to create a completely new disk, offers significant benefits in minimizing downtime. This approach is very effective for deployments with multiple large disks, as it bypasses the time-consuming task of disk creation and data transfer.
+
+Should the native disk update operation encounter limitations, indicated by a `Bosh::Clouds::NotSupported` error, due to either the infrastructure's inability to process the request or if the method is not implemented, the Director will default to generating a new disk and migrating the data.
+
+!!! note
+    Before enabling this feature, ensure that the `director.enable_cpi_resize_disk` property is disabled, as the Director gives priority to the `resize_disk` method due to its broader implementation across CPIs. However, it's worth noting that the `update_disk` method not only matches the capabilities of `resize_disk` but also offers the additional functionality of updating cloud properties.
+
+## Arguments
+
+ * `disk_cid` [String]: Cloud ID of the disk to update; returned from `create_disk`.
+ * `new_size` [Integer]: New disk size in MiB.
+ * `cloud_properties` [Hash]: New cloud properties for the disk. The properties are specific to the IaaS and are opaque to the Director. The Director does not validate the properties and passes them to the CPI as-is.
+
+## Result
+
+No return value
+
+## Examples
+
+### Implementations
+
+ * [cloudfoundry/bosh-azure-cpi-release](https://github.com/cloudfoundry/bosh-azure-cpi-release/blob/fc16e6f65b0533f83052812dc0d6c1edefc9ac28/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb#L482)
+
+## Related
+
+ * [resize_disk](resize-disk.md)
+ * [create_disk](create-disk.md)

--- a/content/google.md
+++ b/content/google.md
@@ -48,6 +48,7 @@ The CPI does not support multiple NICs being attached to a VM.
 | --------------------------------- | ------------------------------------- |
 | Multi-CPI                         | Not Supported                         |
 | Native Disk Resize                | Not Supported                         |
+| Native Disk Update                | Not Supported                         |
 | Generic VM Resource Configuration | Supported, [v27.0.0][google_cpi_v27]+ |
 
 [google_cpi_v27]: https://github.com/cloudfoundry/bosh-google-cpi-release/releases/tag/v27.0.0

--- a/content/openstack.md
+++ b/content/openstack.md
@@ -66,6 +66,7 @@ The CPI supports multiple NICs being attached to a single VM.
 | --------------------------------- | ------------------------------------ |
 | Multi-CPI                         | Supported, [v31][openstack_cpi_v31]+ |
 | Native Disk Resize                | Supported, [v33][openstack_cpi_v33]+ |
+| Native Disk Update                | Not Supported                        |
 | Generic VM Resource Configuration | Supported, [v31][openstack_cpi_v31]+ |
 
 [openstack_cpi_v31]: https://github.com/cloudfoundry/bosh-openstack-cpi-release/releases/tag/v31

--- a/content/vsphere.md
+++ b/content/vsphere.md
@@ -83,5 +83,6 @@ vCenter, no additional configuration is required for the CPI.
 | ------------------ | ---------------------------------- |
 | Multi-CPI          | Supported, [v34][vsphere_cpi_v34]+ |
 | Native Disk Resize | Not Supported                      |
+| Native Disk Update | Not Supported                      |
 
 [vsphere_cpi_v34]: https://github.com/cloudfoundry/bosh-vsphere-cpi-release/releases/tag/v34

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -202,6 +202,7 @@ pages:
         - info: cpi-api-v2-method/info.md
         - reboot_vm: cpi-api-v2-method/reboot-vm.md
         - resize_disk: cpi-api-v2-method/resize-disk.md
+        - update_disk: cpi-api-v2-method/update-disk.md
         - set_disk_metadata: cpi-api-v2-method/set-disk-metadata.md
         - set_vm_metadata: cpi-api-v2-method/set-vm-metadata.md
         - snapshot_disk: cpi-api-v2-method/snapshot-disk.md


### PR DESCRIPTION
* marks the Native Disk Resize feature as supported on Azure (which was seemingly forgotten).
* marks the Native Disk Update feature as supported for Azure in the next CPI release (`v50.0.0`?)
* adds documentation which explains the newly introduced `update_disk` method
* moves the `disk_size` property outside of the `cloud_properties` block, as `disk_size` is not a cloud property.