### PR TITLE
Update cli-v2.md and add flag "--skip-upload-releases" for cmd bosh deploy

### DIFF
--- a/content/cli-v2.md
+++ b/content/cli-v2.md
@@ -966,7 +966,7 @@ See [CPI config](cpi-config.md).
     - `--canaries=NUMBER or PERCENTAGE` Override manifest values for canaries
     - `--max-in-flight=NUMBER or PERCENTAGE` Override manifest values for max_in_flight
     - `--dry-run` Renders job templates without altering a deployment. It will save some state in the director database (like ip reservations) which will be reused on the next deploy
-    - `--force-latest-variables` Causes the director to retreive the latest value of all variables from the config server, overriding their update strategies.  Available as of director version
+    - `--force-latest-variables` Causes the director to retreive the latest value of all variables from the config server, overriding their update strategies.  Available as of director version v279.0.0
     - `--skip-upload-releases` Prevents uploads of releases
     - `PATH` Path to a manifest file
 

--- a/content/cli-v2.md
+++ b/content/cli-v2.md
@@ -967,7 +967,7 @@ See [CPI config](cpi-config.md).
     - `--max-in-flight=NUMBER or PERCENTAGE` Override manifest values for max_in_flight
     - `--dry-run` Renders job templates without altering a deployment. It will save some state in the director database (like ip reservations) which will be reused on the next deploy
     - `--force-latest-variables` Causes the director to retreive the latest value of all variables from the config server, overriding their update strategies.  Available as of director version v279.0.0
-    - `--skip-upload-releases` Prevents uploads of releases
+    - `--skip-upload-releases` Prevents uploads of releases. Available as of director version v279.0.0
     - `PATH` Path to a manifest file
 
     ```shell

--- a/content/cli-v2.md
+++ b/content/cli-v2.md
@@ -945,7 +945,7 @@ See [CPI config](cpi-config.md).
 
 #### Deploy {: #deploy }
 
-- `bosh [GLOBAL-CLI-OPTIONS] deploy [-v ...] [--var-file=VAR=PATH] [-l ...] [--vars-env=PREFIX] [--vars-store=PATH] [-o ...] [--no-redact] [--recreate] [--recreate-persistent-disks] [--fix] [--skip-drain=[INSTANCE-GROUP[/INSTANCE-ID]]] [--canaries=NUMBER or PERCENTAGE] [--max-in-flight=NUMBER or PERCENTAGE] [--dry-run] [--force-latest-variables] PATH`
+- `bosh [GLOBAL-CLI-OPTIONS] deploy [-v ...] [--var-file=VAR=PATH] [-l ...] [--vars-env=PREFIX] [--vars-store=PATH] [-o ...] [--no-redact] [--recreate] [--recreate-persistent-disks] [--fix] [--skip-drain=[INSTANCE-GROUP[/INSTANCE-ID]]] [--canaries=NUMBER or PERCENTAGE] [--max-in-flight=NUMBER or PERCENTAGE] [--dry-run] [--force-latest-variables] [--skip-upload-releases] PATH`
 
     Create or update specified deployment according to the provided manifest. Operation files and variables can be provided to adjust and fill in manifest before deploy begins.
 
@@ -966,7 +966,8 @@ See [CPI config](cpi-config.md).
     - `--canaries=NUMBER or PERCENTAGE` Override manifest values for canaries
     - `--max-in-flight=NUMBER or PERCENTAGE` Override manifest values for max_in_flight
     - `--dry-run` Renders job templates without altering a deployment. It will save some state in the director database (like ip reservations) which will be reused on the next deploy
-    - `--force-latest-variables` Causes the director to retreive the latest value of all variables from the config server, overriding their update strategies.  Available as of director version v279.0.0
+    - `--force-latest-variables` Causes the director to retreive the latest value of all variables from the config server, overriding their update strategies.  Available as of director version
+    - `--skip-upload-releases` Prevents uploads of releases
     - `PATH` Path to a manifest file
 
     ```shell


### PR DESCRIPTION
For bosh deploy cmd SAP bosh team is introducing the new flag "skip-upload-releases". If flagged no upload of releases is going to be triggered during bosh deploy. This flag was introduced for edge case customer with no internet connection. The have compiled releases available but during bosh deploy releases were redownloaded.

Please see also PR https://github.com/cloudfoundry/bosh-cli/pull/679. Here new flag was introduced into deploy.go.