### PR TITLE
Fix styling for AZ migration warning

### DIFF
--- a/content/azs.md
+++ b/content/azs.md
@@ -139,7 +139,8 @@ VMs total: 4
     planning an AZ migration.
 
 
-!!! General limitations
+!!! danger "General limitations"
+
     - Bosh does not migrate persistent disk contents across availability
       zones. Persistent disks attached to an instance (VM) that is moved to
       another AZ will be orphaned and eventually deleted by Bosh.


### PR DESCRIPTION
Spotted a minor styling / readability problem on the AZs page due to bad markdown. Also specifically updated the note to be "danger" since data loss can occur if you attempt to move something with persistent disks across AZs.

Before:
<img width="853" alt="Screenshot 2025-02-20 at 3 11 08 PM" src="https://github.com/user-attachments/assets/03f62abf-972a-4882-bad6-cdc0b22b9f31" />

After:
<img width="855" alt="Screenshot 2025-02-20 at 3 09 17 PM" src="https://github.com/user-attachments/assets/93a56012-8f80-466d-8428-0cf358538d6e" />
