### PR TITLE
Remove incorrect statement about stembuild

### DIFF
--- a/content/windows-os.md
+++ b/content/windows-os.md
@@ -1,10 +1,8 @@
 # Stemcell OS: Microsoft Windows Server
 
 The Microsoft Windows images are built from the
-[cloudfoundry/stembuild](https://github.com/cloudfoundry/stembuild)
-repository. Previously, they were built from
 [cloudfoundry/bosh-windows-stemcell-builder](https://github.com/cloudfoundry/bosh-windows-stemcell-builder)
-(deprecated).
+repository.
 
 ## Distributions
 


### PR DESCRIPTION
The `stembuild` binary has never been used to build Windows stemcells for public IaaSs