### PR TITLE
Clarify that bosh_tasks_total metrics only includes active tasks

### DIFF
--- a/content/director-metrics.md
+++ b/content/director-metrics.md
@@ -33,7 +33,7 @@ Currently it exposes the following metrics:
 
 * `bosh_resurrection_enabled`: Status of resurrection. 0 for disabled, 1 for
   enabled.
-* `bosh_tasks_total`: Number of BOSH tasks, labeled with their current state.
+* `bosh_tasks_total`: Number of BOSH active tasks, labeled with their current state (either 'processing' or 'queued') and type.
 * `bosh_networks_dynamic_ips_total`: Size of network pool for all dynamically
   allocated IP addresses.
 * `bosh_networks_dynamic_free_ips_total`: Number of free dynamic IP addresses


### PR DESCRIPTION
See https://github.com/cloudfoundry/bosh/commit/cf7e1467bd3834e81b0bf1868a3d1f4692ee88e3
> Add gauge metric for active tasks per type

Confirmed by running promql `sum by (state) (bosh_tasks_total)` returning:

```
{state="processing"}
{state="queued"}
```