### PR TITLE
Refine vsphere-storage-vmotion

### DIFF
--- a/content/vsphere-vmotion-support.md
+++ b/content/vsphere-vmotion-support.md
@@ -1,3 +1,15 @@
+This topic describes how storage vmotion:
+* is used by bosh 
+* or may affect bosh deployments when triggered independently of bosh 
+
+## Bosh director using storage vmotion to move persistent disks across data stores
+
+When updating to desired datastore for a deployment (see [Migrating Datastores](vsphere-migrate-datastores.md)), the vsphere cpi attempts to use vsphere storage vmotion to migrate data from source persistent disk to target persistent disk. This is significantly faster than the usual disk resize method in which the bosh agent is copying the data across disks using the `tar` command.
+
+## Vsphere infrastructure pro-actively moving disks across data stores  
+
+It is possible for an operator to proactively move disks across datastores without coordination with the bosh director. This may be done manually, through the vsphere api (potentially through community projects, see https://github.com/vmware-tanzu/vmotion-migration-tool-for-bosh-deployments ), or through vsphere storage DRS. This does not require VMs and bosh jobs to be stopped.
+
 !!! note
     Storage DRS and vMotion can be used with bosh-vsphere-cpi v18+.
 
@@ -11,3 +23,4 @@ Later versions of the CPI are able to locate disks migrated by vSphere as long a
 
 As VMs are recreated, the CPI will move persistent disks out of VM folders so that they are not deleted with the VMs.
 This procedure will happen automatically when VMs are deleted (in `delete_vm` CPI call) and when disks are detached (in `detach_disk` CPI call).
+


### PR DESCRIPTION
Clarify that bosh cpi can trigger storage vmmotion during datastore migrations.

See related commits
https://github.com/cloudfoundry/bosh-vsphere-cpi-release/commit/2072de1fbd311dd930c753b17c2a999ecec662e7
> Client#move_disk uses virtual_disk#move_virtual_disk instead of
> file_manager#move_file as this seems like a better way to move (and
> rename) virtual disks.

 https://github.com/cloudfoundry/bosh-vsphere-cpi-release/commit/73a9de1870fa0aca1fd9cdc678a791d60dbb9846
> Enable move/migrate disk lifecycle specs for VSAN.
> The commit 652d74fa92d69db20ee323ee65e5441cec8f336e recently changed
> Client#move_disk to use virtual_disk#move_virtual_disk instead of
> file_manager#move_file, as it's a better method for moving disks.