### PR TITLE
Enhance update_disk documentation

### DIFF
--- a/content/cpi-api-v2-method/update-disk.md
+++ b/content/cpi-api-v2-method/update-disk.md
@@ -14,6 +14,17 @@ Should the native disk update operation encounter limitations, indicated by a `B
 !!! note
     Before enabling this feature, ensure that the `director.enable_cpi_resize_disk` property is disabled, as the Director gives priority to the `resize_disk` method due to its broader implementation across CPIs. However, it's worth noting that the `update_disk` method not only matches the capabilities of `resize_disk` but also offers the additional functionality of updating cloud properties.
 
+## Director behavior during VM recreation
+
+When `enable_cpi_update_disk` is enabled and a VM is being recreated (e.g., due to a stemcell update or cloud property change), the Director calls `update_disk` while the disk is already in a detached state. This avoids a redundant detach-update-attach cycle:
+
+1. Detach disk from the old VM
+2. Call `update_disk` (disk is already detached)
+3. Delete old VM, create new VM
+4. Attach the (possibly new) disk to the new VM
+
+If the CPI does not support `update_disk`, the Director falls back to the standard copy-based disk update path transparently.
+
 ## Arguments
 
  * `disk_cid` [String]: Cloud ID of the disk to update; returned from `create_disk`.
@@ -22,13 +33,36 @@ Should the native disk update operation encounter limitations, indicated by a `B
 
 ## Result
 
-No return value
+ * `new_disk_cid` [String or nil]: If the disk was replaced (e.g., via snapshot and recreate due to an incompatible type change), returns the new disk's Cloud ID. The Director persists this new CID and uses it for subsequent operations. Returns `nil` if the disk was updated in-place (e.g., a size-only change).
 
 ## Examples
+
+### API
+
+```json
+[
+  "disk-cid-abc123",
+  32768,
+  {"type": "hyperdisk-balanced"}
+]
+```
+
+**Response (disk replaced):**
+
+```json
+"new-disk-cid-def456"
+```
+
+**Response (in-place update):**
+
+```json
+null
+```
 
 ### Implementations
 
  * [cloudfoundry/bosh-azure-cpi-release](https://github.com/cloudfoundry/bosh-azure-cpi-release/blob/fc16e6f65b0533f83052812dc0d6c1edefc9ac28/src/bosh_azure_cpi/lib/cloud/azure/cloud.rb#L482)
+ * [cloudfoundry/bosh-google-cpi-release](https://github.com/cloudfoundry/bosh-google-cpi-release/blob/master/src/bosh-google-cpi/action/update_disk.go)
 
 ## Related
 

--- a/content/cpi-api-v2-method/update-disk.md
+++ b/content/cpi-api-v2-method/update-disk.md
@@ -33,7 +33,7 @@ If the CPI does not support `update_disk`, the Director falls back to the standa
 
 ## Result
 
- * `new_disk_cid` [String or nil]: If the disk was replaced (e.g., via snapshot and recreate due to an incompatible type change), returns the new disk's Cloud ID. The Director persists this new CID and uses it for subsequent operations. Returns `nil` if the disk was updated in-place (e.g., a size-only change).
+ * `new_disk_cid` [String or nil]: If the disk was replaced (e.g., via snapshot and recreate due to an incompatible type change), returns the new disk's Cloud ID. The Director persists this new CID and uses it for subsequent operations. If the disk was updated in-place, the CPI may return `nil` or the original disk CID - in both cases, the Director continues using the existing CID.
 
 ## Examples
 

--- a/content/cpi-api-v2-method/update-disk.md
+++ b/content/cpi-api-v2-method/update-disk.md
@@ -23,7 +23,7 @@ When `enable_cpi_update_disk` is enabled and a VM is being recreated (e.g., due 
 3. Delete old VM, create new VM
 4. Attach the (possibly new) disk to the new VM
 
-If the CPI does not support `update_disk`, the Director falls back to the standard copy-based disk update path transparently.
+If the CPI does not support `update_disk`, the Director falls back to the standard copy-based disk migration path transparently.
 
 ## Arguments
 


### PR DESCRIPTION
## Summary

- Document that `update_disk` can return a new disk CID when the disk is replaced (e.g., snapshot-based type change on GCP). Previously documented as "No return value".
- Add section on Director behavior during VM recreation: the Director now calls `update_disk` while the disk is already detached, avoiding a redundant detach-update-attach cycle.
- Add API request/response examples showing both the disk-replaced and in-place-update cases.
- Add the Google CPI (`bosh-google-cpi-release`) to the Implementations list.

## Context

These changes reflect the new `update_disk` behavior introduced in:
- [cloudfoundry/bosh#2701](https://github.com/cloudfoundry/bosh/pull/2701) - Director persists new disk CID from `update_disk` return value and calls it during recreation
- [cloudfoundry/bosh-google-cpi-release#382](https://github.com/cloudfoundry/bosh-google-cpi-release/pull/382) - GCP CPI implementation of `update_disk` (snapshot-based type migration)