### PR TITLE
Document that lifecycle scripts run at lower CPU priority than the agent

### DIFF
--- a/content/drain.md
+++ b/content/drain.md
@@ -29,6 +29,9 @@ templates:
 
 Drain script is usually just a regular shell script. Since drain script is executed in a similar way as other release job scripts (start, stop, pre-start scripts) you can use job's package dependencies.
 
+!!! note
+    Drain scripts run at a lower CPU scheduling priority than the BOSH agent to keep the agent responsive. See [Job Lifecycle](job-lifecycle.md) for details.
+
 Drain script should be idempotent. It may be called multiple times before or after process is stopped.
 
 You must ensure that your drain script exits in one of following ways:

--- a/content/job-lifecycle.md
+++ b/content/job-lifecycle.md
@@ -26,6 +26,9 @@ There are several stages that all jobs (and their associated processes) on each 
 !!! note
     Scripts should not rely on the order they are run. Agent may decide to run them serially or in parallel.
 
+!!! note
+    All lifecycle scripts (pre-start, post-start, post-deploy, pre-stop, drain, post-stop) are spawned at a lower CPU scheduling priority than the BOSH agent itself. This prevents CPU-intensive scripts from starving the agent's event loop, which would otherwise cause the Director to report an agent-unreachable error even though the script is making progress.
+
 ---
 ## When processes are running {: #running }
 

--- a/content/post-deploy.md
+++ b/content/post-deploy.md
@@ -49,6 +49,9 @@ Post-deploy script is called every time after job is started (ctl script is call
 
 Post-deploy scripts in a deployment are executed in parallel.
 
+!!! note
+    Post-deploy scripts run at a lower CPU scheduling priority than the BOSH agent to keep the agent responsive. See [Job Lifecycle](job-lifecycle.md) for details.
+
 ---
 ## Logs {: #logs }
 

--- a/content/post-start.md
+++ b/content/post-start.md
@@ -41,6 +41,9 @@ Post-start script is called every time after job is started (ctl script is calle
 
 Post-start scripts in a single deployment job (typically is composed of multiple release jobs) are executed in parallel.
 
+!!! note
+    Post-start scripts run at a lower CPU scheduling priority than the BOSH agent to keep the agent responsive. See [Job Lifecycle](job-lifecycle.md) for details.
+
 ---
 ## Logs {: #logs }
 

--- a/content/post-stop.md
+++ b/content/post-stop.md
@@ -28,3 +28,6 @@ templates:
 Post-stop script is usually just a regular shell script. Since post-start script is executed in a similar way as other release job scripts (start, stop, drain scripts) you can use job's package dependencies.
 
 Post-stop script should be idempotent. It may be called multiple times after a process is stopped.
+
+!!! note
+    Post-stop scripts run at a lower CPU scheduling priority than the BOSH agent to keep the agent responsive. See [Job Lifecycle](job-lifecycle.md) for details.

--- a/content/pre-start.md
+++ b/content/pre-start.md
@@ -44,6 +44,9 @@ Pre-start script is called every time before job is started (ctl script is calle
 
 Pre-start scripts in a single deployment job (typically is composed of multiple release jobs) are executed in parallel.
 
+!!! note
+    Pre-start scripts run at a lower CPU scheduling priority than the BOSH agent to keep the agent responsive. See [Job Lifecycle](job-lifecycle.md) for details.
+
 ---
 ## Logs {: #logs }
 

--- a/content/pre-stop.md
+++ b/content/pre-stop.md
@@ -31,6 +31,9 @@ A pre-stop script is usually just a regular shell script. Since the pre-start sc
 
 The pre-stop script also uses an exit code to indicate its success (exit code 0) or failure (any other exit code). A pre-stop script should be idempotent.
 
+!!! note
+    Pre-stop scripts run at a lower CPU scheduling priority than the BOSH agent to keep the agent responsive. See [Job Lifecycle](job-lifecycle.md) for details.
+
 ---
 ## Environment Variables {: #environment-variables }
 


### PR DESCRIPTION
Lifecycle scripts (pre-start, post-start, post-deploy, pre-stop, drain, post-stop) are now spawned with lower CPU scheduling priority than the BOSH agent itself. This prevents CPU-intensive scripts from starving the agent's event loop and causing spurious agent-unreachable errors during deployment.

References:
- cloudfoundry/bosh-agent#438
- cloudfoundry/bosh-utils#142