### PR TITLE
docs: add new agent/instance health metrics (bosh#2649)

### DIFF
--- a/content/director-metrics.md
+++ b/content/director-metrics.md
@@ -40,11 +40,11 @@ The metrics server serves two endpoints, `/metrics` and `/api_metrics`. Currentl
 * `bosh_networks_dynamic_ips_total`: Size of network pool for all dynamically allocated IP addresses.
 * `bosh_networks_dynamic_free_ips_total`: Number of free dynamic IP addresses left per network.
 * `bosh_unresponsive_agents`: Number of unresponsive agents per deployment.
-* `bosh_unhealthy_agents`: Number of unhealthy agents per deployment. An agent is considered unhealthy when its `job_state` is `running` but it has zero running processes (`number_of_processes == 0`).
-* `bosh_total_available_agents`: Total number of available agents per deployment (all agents, regardless of state). Also includes an `unmanaged` label for agents not associated with any deployment.
-* `bosh_failing_instances`: Number of instances with `job_state == "failing"` per deployment.
-* `bosh_stopped_instances`: Number of instances with `job_state == "stopped"` per deployment.
-* `bosh_unknown_instances`: Number of instances with an unknown (nil) `job_state` per deployment.
+* `bosh_unhealthy_agents`: Number of unhealthy agents per deployment. An agent is considered unhealthy when it is running but has no active processes.
+* `bosh_total_available_agents`: Total number of agents per deployment regardless of state, including agents not associated with any deployment.
+* `bosh_failing_instances`: Number of failing instances per deployment.
+* `bosh_stopped_instances`: Number of stopped instances per deployment.
+* `bosh_unknown_instances`: Number of instances with an unknown state per deployment.
 * Generic API metrics for the director's endpoints including number of requests and response time.
 
 ## BOSH Director VM Metrics

--- a/content/director-metrics.md
+++ b/content/director-metrics.md
@@ -41,7 +41,7 @@ The metrics server serves two endpoints, `/metrics` and `/api_metrics`. Currentl
 * `bosh_networks_dynamic_free_ips_total`: Number of free dynamic IP addresses left per network.
 * `bosh_unresponsive_agents`: Number of unresponsive agents per deployment.
 * `bosh_unhealthy_agents`: Number of unhealthy agents per deployment. An agent is considered unhealthy when it is running but has no active processes.
-* `bosh_total_available_agents`: Total number of agents per deployment regardless of state, including agents not associated with any deployment.
+* `bosh_total_available_agents`: Total number of agents per deployment regardless of state, including agents reported under the `unmanaged` label for rogue agents.
 * `bosh_failing_instances`: Number of failing instances per deployment.
 * `bosh_stopped_instances`: Number of stopped instances per deployment.
 * `bosh_unknown_instances`: Number of instances with an unknown state per deployment.

--- a/content/director-metrics.md
+++ b/content/director-metrics.md
@@ -39,7 +39,12 @@ The metrics server serves two endpoints, `/metrics` and `/api_metrics`. Currentl
 * `bosh_tasks_total`: Number of BOSH active tasks, labeled with their current state (either 'processing' or 'queued') and type.
 * `bosh_networks_dynamic_ips_total`: Size of network pool for all dynamically allocated IP addresses.
 * `bosh_networks_dynamic_free_ips_total`: Number of free dynamic IP addresses left per network.
-* `bosh_unresponsive_agents`: Number of unresponsive agents per deployment
+* `bosh_unresponsive_agents`: Number of unresponsive agents per deployment.
+* `bosh_unhealthy_agents`: Number of unhealthy agents per deployment. An agent is considered unhealthy when its `job_state` is `running` but it has zero running processes (`number_of_processes == 0`).
+* `bosh_total_available_agents`: Total number of available agents per deployment (all agents, regardless of state). Also includes an `unmanaged` label for agents not associated with any deployment.
+* `bosh_failing_instances`: Number of instances with `job_state == "failing"` per deployment.
+* `bosh_stopped_instances`: Number of instances with `job_state == "stopped"` per deployment.
+* `bosh_unknown_instances`: Number of instances with an unknown (nil) `job_state` per deployment.
 * Generic API metrics for the director's endpoints including number of requests and response time.
 
 ## BOSH Director VM Metrics


### PR DESCRIPTION
## Summary

Documents the five new Prometheus metrics introduced in cloudfoundry/bosh#2649:

- `bosh_unhealthy_agents` — agents where `job_state == "running"` but `number_of_processes == 0`, per deployment.
- `bosh_total_available_agents` — total agents per deployment (all states); includes an `unmanaged` label for rogue agents.
- `bosh_failing_instances` — instances with `job_state == "failing"`, per deployment.
- `bosh_stopped_instances` — instances with `job_state == "stopped"`, per deployment.
- `bosh_unknown_instances` — instances with an unknown (`nil`) `job_state`, per deployment.

All five metrics are labeled by deployment name and served via the existing `/metrics` endpoint.

## Related

- cloudfoundry/bosh#2649