### PR TITLE
ci: fix `build.yml` task mkdocs path

### DIFF
--- a/ci/tasks/build.yml
+++ b/ci/tasks/build.yml
@@ -6,7 +6,7 @@ image_resource:
     tag: 9.7.6
 run:
   dir: docs
-  path: /usr/bin/mkdocs
+  path: /usr/local/bin/mkdocs
   args:
   - build
   - --site-dir=../docroot


### PR DESCRIPTION
Fixes this issue caused by the `mkdocs-material` upgrade.

see: https://github.com/cloudfoundry/docs-bosh/pull/908
fixes: https://github.com/cloudfoundry/bosh-io-web/pull/81#issuecomment-4929539085